### PR TITLE
Feature/export optimization

### DIFF
--- a/regolith/export.go
+++ b/regolith/export.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/otiai10/copy"
+	"golang.org/x/sys/windows"
 )
 
 // GetExportPaths returns file paths for exporting behavior pack and
@@ -99,18 +100,18 @@ func ExportProject(profile Profile, name string) error {
 	}
 
 	Logger.Info("Exporting project to ", bpPath)
-	err = MoveOrCopy(".regolith/tmp/BP", bpPath, exportTarget.ReadOnly)
+	err = MoveOrCopy(".regolith/tmp/BP", bpPath, exportTarget.ReadOnly, true)
 	if err != nil {
 		return err
 	}
 
 	Logger.Info("Exporting project to ", rpPath)
-	err = MoveOrCopy(".regolith/tmp/RP", rpPath, exportTarget.ReadOnly)
+	err = MoveOrCopy(".regolith/tmp/RP", rpPath, exportTarget.ReadOnly, true)
 	if err != nil {
 		return err
 	}
 
-	err = MoveOrCopy(".regolith/tmp/data", profile.DataPath, false)
+	err = MoveOrCopy(".regolith/tmp/data", profile.DataPath, false, false)
 	if err != nil {
 		return err
 	}
@@ -124,17 +125,60 @@ func ExportProject(profile Profile, name string) error {
 	return err
 }
 
+// copyFileSecurityInfo copies the DACL info from source path to DACL of
+// the target path
+func copyFileSecurityInfo(source string, target string) error {
+	securityInfo, err := windows.GetNamedSecurityInfo(
+		source,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return wrapError(
+			fmt.Sprintf("Unable to get security info of %q.", source), err)
+	}
+	dacl, _, err := securityInfo.DACL()
+	if err != nil {
+		return wrapError(
+			fmt.Sprintf("Unable to get DACL of %q.", source), err)
+	}
+	err = windows.SetNamedSecurityInfo(
+		target,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION, nil, nil, dacl, nil,
+	)
+	if err != nil {
+		return wrapError(
+			fmt.Sprintf("Unable to set DACL of %q.", target), err)
+	}
+	return nil
+}
+
 // MoveOrCopy tries to move the the source to destination first and in case
 // of failore it copies the files instead.
-//
-// TODO - implement the "move" part of this function without repeating the
-// problem of issue #85. Current version of this function always copies
-// the files.
-func MoveOrCopy(source string, destination string, makeReadOnly bool) error {
-	copyOptions := copy.Options{PreserveTimes: false, Sync: false}
-	err := copy.Copy(source, destination, copyOptions)
-	if err != nil {
-		return wrapError(fmt.Sprintf("Couldn't copy data files to %s, aborting.", destination), err)
+func MoveOrCopy(
+	source string, destination string, makeReadOnly bool, copyParentAcl bool,
+) error {
+	if err := os.Rename(source, destination); err != nil {
+		Logger.Infof("Couldn't move files to %s. Trying to copy files instead...", destination)
+		copyOptions := copy.Options{PreserveTimes: false, Sync: false}
+		err := copy.Copy(source, destination, copyOptions)
+		if err != nil {
+			return wrapError(fmt.Sprintf("Couldn't copy data files to %s, aborting.", destination), err)
+		}
+	} else if copyParentAcl { // No errors with moving files but needs ACL copy
+		parent := filepath.Dir(destination)
+		if _, err := os.Stat(parent); os.IsNotExist(err) {
+			return err
+		}
+		err = copyFileSecurityInfo(parent, destination)
+		if err != nil {
+			return wrapError(
+				fmt.Sprintf(
+					"Counldn't set ACL to the target file %s, aborting.",
+					destination),
+				err,
+			)
+		}
 	}
 	// Make files read only if this option is selected
 	if makeReadOnly {


### PR DESCRIPTION
- Fixed read only export feature #94.
- Regolith uses `os.Rename` while exporting files. If that fails, it copies the files. When the `os.Rename` is used Regolith additionally updtes the ACL of renamed files to match the ACL of the parent of rename destination. Issue #87 