### PR TITLE
Fix 2 doc errors in filters/custom-filters.md

### DIFF
--- a/docs/_pages/docs/filters/custom-filters.md
+++ b/docs/_pages/docs/filters/custom-filters.md
@@ -40,7 +40,7 @@ Example:
 
 You can use the following "runWith" types:
  - python
- - node
+ - nodejs
  - java
  - nim
  - shell
@@ -80,7 +80,7 @@ Here is an example:
 }
 ```
 
-This will generate: `python ./filters/message.py {'hello':'world'}`
+This will generate: `python ./filters/message.py {'message':'Hello World!'}`
 
 This is useful for passing user-defined settings into your filter. Simply handle the first argument in the argument array, and interpret it as json!
 


### PR DESCRIPTION
'This will generate:' line was incorrectly stating `{'hello':'world'}` instead of `{'message':'Hello World!'}`
`node` was listed as a `runWith` type, which does not exist. Edited to `nodejs`