### PR TITLE
Fix online filter url example

### DIFF
--- a/docs/_pages/docs/filters/online-filters.md
+++ b/docs/_pages/docs/filters/online-filters.md
@@ -17,7 +17,7 @@ To add an online filter to your profile, you must write like this:
 
 ```json
 {
-  "url": "https://github.com/username/repository/folder"
+  "url": "github.com/username/repository/folder"
 }
 ```
 


### PR DESCRIPTION
The example filter listed under `Running an Online Filter` contained `https://`, which causes an error when used