### PR TITLE
Fixed Regolith crashes when the BP or RP path is missing. Close #119.

### DIFF
--- a/test/common.go
+++ b/test/common.go
@@ -15,6 +15,7 @@ const minimalProjectPath = "testdata/minimal_project"
 const multitargetProjectPath = "testdata/multitarget_project"
 const doubleRemoteProjectPath = "testdata/double_remote_project"
 const doubleRemoteProjectInstalledPath = "testdata/double_remote_project_installed"
+const runMissingRpProjectPath = "testdata/run_missing_rp_project"
 
 // listPaths returns a dictionary with paths of the files from 'path' directory
 // relative to 'root' directory used as keys, and with md5 hashes paths as

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -1,0 +1,55 @@
+package test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"bedrock-oss.github.com/regolith/regolith"
+	"github.com/otiai10/copy"
+)
+
+// TestRegolithRunMissingRp tests the behavior of RunProfile when the packs/RP
+// directory is missing.
+func TestRegolithRunMissingRp(t *testing.T) {
+	// SETUP
+	// Switching working directories in this test, make sure to go back
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("Unable to get current working directory")
+	}
+	defer os.Chdir(wd)
+	// Create a temporary directory
+	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	if err != nil {
+		t.Fatal("Unable to create temporary directory:", err)
+	}
+	t.Log("Created temporary directory:", tmpDir)
+	// Before deleting "workingDir" the test must stop using it
+	defer os.RemoveAll(tmpDir)
+	defer os.Chdir(wd)
+	os.Mkdir(tmpDir, 0666)
+	// Copy the test project to the working directory
+	err = copy.Copy(
+		runMissingRpProjectPath,
+		tmpDir,
+		copy.Options{PreserveTimes: false, Sync: false},
+	)
+	if err != nil {
+		t.Fatalf(
+			"Failed to copy test files %q into the working directory %q",
+			multitargetProjectPath, tmpDir,
+		)
+	}
+	// Switch to the working directory
+	os.Chdir(tmpDir)
+
+	// THE TEST
+	// 1. Run Regolith (export to A)
+	regolith.InitLogging(true)
+	err = regolith.RunProfile("dev")
+	if err != nil {
+		t.Fatal(
+			"RunProfile failed:", err)
+	}
+}

--- a/test/testdata/README.md
+++ b/test/testdata/README.md
@@ -13,3 +13,5 @@ This folder is used to store resources used for testing.
     The filter has a reference to another remote filter on the same reposiotry.
 - `double_remote_project_installed` - expected result of contents of
     `double_remote_project` after installation.
+- `run_missing_rp_project` - a project that for testing `regolith run` which is
+  missing `packs/RP`. The profile doesn't have any filters.

--- a/test/testdata/run_missing_rp_project/.gitignore
+++ b/test/testdata/run_missing_rp_project/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.regolith

--- a/test/testdata/run_missing_rp_project/config.json
+++ b/test/testdata/run_missing_rp_project/config.json
@@ -1,0 +1,19 @@
+{
+	"name": "filter_tester example",
+	"author": "Bedrock-OSS",
+	"packs": {
+		"behaviorPack": "./packs/BP"
+	},
+	"regolith": {
+		"profiles": {
+			"dev": {
+				"filters": [],
+				"export": {
+					"target": "local",
+					"readOnly": true
+				},
+				"dataPath": "./data"
+			}
+		}
+	}
+}

--- a/test/testdata/run_missing_rp_project/packs/BP/example.txt
+++ b/test/testdata/run_missing_rp_project/packs/BP/example.txt
@@ -1,0 +1,1 @@
+This is an example file.


### PR DESCRIPTION
All of the directories used inside 'tmp' ('RP', 'BP', 'data') are now created by a single closure inside SetupTmpFiles function.
- If path is not specified (if it's an empty string) an empty folder is created inside 'tmp'
- If the specified path doesn't exist, regolith prints a warning and creates an empty folder inside 'tmp'
- If the path is pointing at a file instead of a directory, regolith stops with an error.