### PR TITLE
Support targeting `com.mojang` in Linux WSL

### DIFF
--- a/docs/_pages/docs/documentation/config.md
+++ b/docs/_pages/docs/documentation/config.md
@@ -82,7 +82,13 @@ Example config, with many options explained:
     },
 
     // The path to your regolith data folder, which contains configuration files for your filter.
-    "dataPath": "./packs/data"
+    "dataPath": "./packs/data",
+
+    // (Only WSL users need to worry about this. If you don't know what WSL is, then you're almost certainly not using it)
+    // "wslUser" sets the username Regolith will try to use to access your com.mojang folder.
+    // This is optional, and defaults to the default non-Windows behavior.
+    // The "username" here should come from the path `C:\Users\<username>\AppData\...`.
+    "wslUser": "username"
   }
 }
 ```

--- a/regolith/compatibility_other_os.go
+++ b/regolith/compatibility_other_os.go
@@ -5,6 +5,9 @@ package regolith
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 )
 
 // venvScriptsPath is a folder name between "venv" and "python" that leads to
@@ -41,7 +44,38 @@ func (d *DirWatcher) Close() error {
 	return fmt.Errorf("Not implemented for this system.")
 }
 
-func FindMojangDir() (string, error) {
-	return "", WrappedErrorf(
-		"Unsupported operating system: '%s'", runtime.GOOS)
+/*
+FindMojangDir locates the com.mojang folder on non-windows platforms.
+
+If the platform is not WSL, this function will return an error.
+
+If WslUser is an empty string, this function will return an error.
+*/
+func FindMojangDir(WslUser string) (string, error) {
+	winUserDir := filepath.Join("/", "mnt", "c", "Users")
+	if _, err := os.Stat(winUserDir); err != nil {
+		return "", WrappedErrorf(
+			"Unsupported operating system: '%s'", runtime.GOOS)
+	}
+
+	if WslUser == "" {
+		return "", WrappedErrorf(
+			"This platform appears to be WSL but the WslUser option was not set.")
+	}
+
+	result := filepath.Join(
+		winUserDir, WslUser, "AppData", "Local", "Packages",
+		"Microsoft.MinecraftUWP_8wekyb3d8bbwe", "LocalState", "games",
+		"com.mojang")
+	if _, err := os.Stat(result); err != nil {
+		if os.IsNotExist(err) {
+			return "", WrapErrorf(
+				err, "The \"com.mojang\" folder is not at \"%s\".\n"+
+					"Does your system have multiple user accounts?", result)
+		}
+		return "", WrapErrorf(
+			err, "Unable to access \"%s\".\n"+
+				"Are your user permissions correct?", result)
+	}
+	return result, nil
 }

--- a/regolith/config.go
+++ b/regolith/config.go
@@ -38,6 +38,7 @@ type RegolithProject struct {
 	FilterDefinitions map[string]FilterInstaller `json:"filterDefinitions"`
 	DataPath          string                     `json:"dataPath,omitempty"`
 	UseAppData        bool                       `json:"useAppData,omitempty"`
+	WslUser           string                     `json:"wslUser,omitempty"`
 }
 
 // ConfigFromObject creates a "Config" object from map[string]interface{}
@@ -161,6 +162,16 @@ func RegolithProjectFromObject(
 		}
 	}
 	result.UseAppData = useAppData
+	// wslUser (optional, empty string by default)
+	wslUser := ""
+	if _, ok := obj["wslUser"]; ok {
+		wslUser, ok = obj["wslUser"].(string)
+		if !ok {
+			return result, WrappedError(
+				"The \"wslUser\" property is not a string.")
+		}
+	}
+	result.WslUser = wslUser
 	return result, nil
 }
 

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -10,10 +10,10 @@ import (
 // resource pack based on exportTarget (a structure with data related to
 // export settings) and the name of the project.
 func GetExportPaths(
-	exportTarget ExportTarget, name string,
+	exportTarget ExportTarget, name string, WslUser string,
 ) (bpPath string, rpPath string, err error) {
 	if exportTarget.Target == "development" {
-		comMojang, err := FindMojangDir()
+		comMojang, err := FindMojangDir(WslUser)
 		if err != nil {
 			return "", "", WrapError(
 				err, "Failed to find \"com.mojang\" directory.")
@@ -49,7 +49,7 @@ func GetExportPaths(
 			rpPath = filepath.Join(
 				exportTarget.WorldPath, "resource_packs", name+"_rp")
 		} else if exportTarget.WorldName != "" {
-			dir, err := FindMojangDir()
+			dir, err := FindMojangDir(WslUser)
 			if err != nil {
 				return "", "", WrapError(
 					err, "Failed to find \"com.mojang\" directory.")
@@ -86,10 +86,10 @@ func GetExportPaths(
 // GetExportPaths. The function uses cached data about the state of the project
 // files to reduce the number of file system operations.
 func RecycledExportProject(
-	profile Profile, name, dataPath, dotRegolithPath string,
+	profile Profile, name, dataPath, dotRegolithPath string, WslUser string,
 ) error {
 	exportTarget := profile.ExportTarget
-	bpPath, rpPath, err := GetExportPaths(exportTarget, name)
+	bpPath, rpPath, err := GetExportPaths(exportTarget, name, WslUser)
 	if err != nil {
 		return WrapError(
 			err, "Failed to get generate export paths.")
@@ -173,10 +173,10 @@ func RecycledExportProject(
 // ExportProject copies files from the tmp paths (tmp/BP and tmp/RP) into
 // the project's export target. The paths are generated with GetExportPaths.
 func ExportProject(
-	profile Profile, name, dataPath, dotRegolithPath string,
+	profile Profile, name, dataPath, dotRegolithPath string, WslUser string,
 ) error {
 	exportTarget := profile.ExportTarget
-	bpPath, rpPath, err := GetExportPaths(exportTarget, name)
+	bpPath, rpPath, err := GetExportPaths(exportTarget, name, WslUser)
 	if err != nil {
 		return WrapError(
 			err, "Failed to get generate export paths.")

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -243,7 +243,7 @@ start:
 	Logger.Info("Moving files to target directory.")
 	start := time.Now()
 	err = RecycledExportProject(
-		profile, context.Config.Name, context.Config.DataPath, context.DotRegolithPath)
+		profile, context.Config.Name, context.Config.DataPath, context.DotRegolithPath, context.Config.WslUser)
 	if err != nil {
 		err1 := ClearCachedStates() // Just to be safe clear cached states
 		if err1 != nil {
@@ -295,7 +295,7 @@ start:
 	Logger.Info("Moving files to target directory.")
 	start := time.Now()
 	err = ExportProject(
-		profile, context.Config.Name, context.Config.DataPath, context.DotRegolithPath)
+		profile, context.Config.Name, context.Config.DataPath, context.DotRegolithPath, context.Config.WslUser)
 	if err != nil {
 		return WrapError(err, "Exporting project failed.")
 	}


### PR DESCRIPTION
WSL users now only need to specify their windows User directory name to target com.mojang.

Added:
- `wslUser` config option (under regolith)
- hading-down of new config option to `FindMojangDir`
- documentation of new config option
- locating `com.mojang` from a WSL system via `/mnt/c/...`