### PR TITLE
feat: FindMojangDir & FindPreviewDir WSL support via wslpath

### DIFF
--- a/regolith/compatibility_other_os.go
+++ b/regolith/compatibility_other_os.go
@@ -5,6 +5,11 @@ package regolith
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 // venvScriptsPath is a folder name between "venv" and "python" that leads to
@@ -41,7 +46,62 @@ func (d *DirWatcher) Close() error {
 	return fmt.Errorf("Not implemented for this system.")
 }
 
+// comMojangDir returns the path to the com.mojang folder, for either
+// Minecraft or Minecraft Preview.
+func comMojangDir(preview bool) (string, error) {
+	if runtime.GOOS != "linux" {
+		return "", WrappedErrorf(
+			"Unsupported operating system: '%s'", runtime.GOOS)
+	}
+
+	if _, err := exec.LookPath("wslpath"); err != nil {
+		return "", WrapErrorf(err, "Could not find wslpath executable (are you running regolith within WSL2?).")
+	}
+	out, err := exec.Command("cmd.exe", "/c", "echo", "%localappdata%").Output()
+	if err != nil {
+		return "", WrapErrorf(err, "Could not find localappdata path.")
+	}
+	localAppData := strings.TrimSpace(string(out))
+
+	packagesDir := "Microsoft.MinecraftUWP_8wekyb3d8bbwe"
+	if preview {
+		packagesDir = "Microsoft.MinecraftWindowsBeta_8wekyb3d8bbwe"
+	}
+
+	result := filepath.Join(
+		localAppData, "Packages",
+		packagesDir, "LocalState", "games",
+		"com.mojang")
+
+	out, err = exec.Command("wslpath", result).Output()
+	if err != nil {
+		return "", WrapErrorf(err, "Could not find resolve path to WSL path.")
+	}
+	wslPath := strings.TrimSpace(string(out))
+
+	if _, err := os.Stat(wslPath); err != nil {
+		if os.IsNotExist(err) {
+			mcName := "Minecraft"
+			if preview {
+				mcName = "Minecraft Preview"
+			}
+			return "", WrapErrorf(
+				err, "The %s \"com.mojang\" folder is not at \"%s\".\n"+
+					"Does your system have multiple user accounts?", mcName, result)
+		}
+		return "", WrapErrorf(
+			err, "Unable to access \"%s\".\n"+
+				"Are your user permissions correct?", wslPath)
+	}
+	return wslPath, nil
+}
+
+// FindMojangDir returns path to the com.mojang folder.
 func FindMojangDir() (string, error) {
-	return "", WrappedErrorf(
-		"Unsupported operating system: '%s'", runtime.GOOS)
+	return comMojangDir(false)
+}
+
+// FindMojangDir returns path to the com.mojang folder for Minecraft Preview.
+func FindPreviewDir() (string, error) {
+	return comMojangDir(true)
 }

--- a/regolith/compatibility_windows.go
+++ b/regolith/compatibility_windows.go
@@ -138,21 +138,38 @@ func (d *DirWatcher) Close() error {
 	return windows.CloseHandle(d.handle)
 }
 
-// FindMojangDir returns path to the com.mojang folder.
-func FindMojangDir() (string, error) {
+func comMojangDir(preview bool) (string, error) {
+	packagesDir := "Microsoft.MinecraftUWP_8wekyb3d8bbwe"
+	if preview {
+		packagesDir = "Microsoft.MinecraftWindowsBeta_8wekyb3d8bbwe"
+	}
 	result := filepath.Join(
 		os.Getenv("LOCALAPPDATA"), "Packages",
-		"Microsoft.MinecraftUWP_8wekyb3d8bbwe", "LocalState", "games",
+		packagesDir, "LocalState", "games",
 		"com.mojang")
 	if _, err := os.Stat(result); err != nil {
 		if os.IsNotExist(err) {
+			mcName := "Minecraft"
+			if preview {
+				mcName = "Minecraft Preview"
+			}
 			return "", WrapErrorf(
-				err, "The \"com.mojang\" folder is not at \"%s\".\n"+
-					"Does your system have multiple user accounts?", result)
+				err, "The %s \"com.mojang\" folder is not at \"%s\".\n"+
+					"Does your system have multiple user accounts?", mcName, result)
 		}
 		return "", WrapErrorf(
 			err, "Unable to access \"%s\".\n"+
 				"Are your user permissions correct?", result)
 	}
 	return result, nil
+}
+
+// FindMojangDir returns path to the com.mojang folder.
+func FindMojangDir() (string, error) {
+	return comMojangDir(false)
+}
+
+// FindMojangDir returns path to the com.mojang folder for Minecraft Preview.
+func FindPreviewDir() (string, error) {
+	return comMojangDir(true)
 }

--- a/regolith/utils_minecraft.go
+++ b/regolith/utils_minecraft.go
@@ -2,10 +2,7 @@ package regolith
 
 import (
 	"io/ioutil"
-	"os"
 	"path"
-	"path/filepath"
-	"runtime"
 )
 
 type World struct {
@@ -52,28 +49,6 @@ func ListWorlds(mojangDir string) ([]*World, error) {
 	var result []*World
 	for _, val := range worlds {
 		result = append(result, &val)
-	}
-	return result, nil
-}
-
-func FindPreviewDir() (string, error) {
-	if runtime.GOOS != "windows" {
-		return "", WrappedErrorf(
-			"Unsupported operating system: '%s'", runtime.GOOS)
-	}
-	result := filepath.Join(
-		os.Getenv("LOCALAPPDATA"), "Packages",
-		"Microsoft.MinecraftWindowsBeta_8wekyb3d8bbwe", "LocalState", "games",
-		"com.mojang")
-	if _, err := os.Stat(result); err != nil {
-		if os.IsNotExist(err) {
-			return "", WrapErrorf(
-				err, "The minecraft preview's \"com.mojang\" folder is not at \"%s\".\n"+
-					"Does your system have multiple user accounts?", result)
-		}
-		return "", WrapErrorf(
-			err, "Unable to access \"%s\".\n"+
-				"Are your user permissions correct?", result)
 	}
 	return result, nil
 }


### PR DESCRIPTION
Thanks @stirante for the WSL support implementation via `wslpath`

I've added support for locating the `com.mojang` folder when running Regolith in WSL, both for typical release Minecraft Bedrock and for preview Minecraft Beta.
In doing so, I've abstracted both functions to a single, more generic `func comMojangDir(preview bool)` which will set itself up for Minecraft Bedrock and Minecraft Beta given the `preview` boolean parameter; the functions were almost identical and DRY says don't do that.

While these could have been removed from the OS-specific compatibility and merged into one, this reverts the last commit and unnecessarily adds complexity.

\*Draft as I want to go over the code and run practical tests