### PR TITLE
Change module name to `github.com/Bedrock-OSS/regolith`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bedrock-oss.github.com/regolith
+module github.com/Bedrock-OSS/regolith
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fatih/color"
 
-	"bedrock-oss.github.com/regolith/regolith"
+	"github.com/Bedrock-OSS/regolith/regolith"
 	"github.com/urfave/cli/v2"
 )
 

--- a/test/export_windows_test.go
+++ b/test/export_windows_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"bedrock-oss.github.com/regolith/regolith"
+	"github.com/Bedrock-OSS/regolith/regolith"
 	"github.com/otiai10/copy"
 	"golang.org/x/sys/windows"
 )

--- a/test/file_protection_test.go
+++ b/test/file_protection_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bedrock-oss.github.com/regolith/regolith"
+	"github.com/Bedrock-OSS/regolith/regolith"
 	"github.com/otiai10/copy"
 )
 

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bedrock-oss.github.com/regolith/regolith"
+	"github.com/Bedrock-OSS/regolith/regolith"
 	"github.com/otiai10/copy"
 )
 

--- a/test/recycled_copy_test.go
+++ b/test/recycled_copy_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bedrock-oss.github.com/regolith/regolith"
+	"github.com/Bedrock-OSS/regolith/regolith"
 	"github.com/otiai10/copy"
 )
 

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bedrock-oss.github.com/regolith/regolith"
+	"github.com/Bedrock-OSS/regolith/regolith"
 	"github.com/otiai10/copy"
 )
 


### PR DESCRIPTION
Hello everyone,

I've recently tried to install regolith using `go install github.com/Bedrock-OSS/regolith`, which didn't work as the module name was `bedrock-oss.github.com/regolith`. The old module name is sadly not importable from anywhere outside the project, including from `go install` as Go is looking for the source code using that URL.

This PR replaces the module name with the right one for the project: `github.com/Bedrock-OSS/regolith`

Hope this helps and looking forward to further contributing on this project,
Kevin