### PR TITLE
Modify Permissions for Directory creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dist/
 /vendor/
+/bin/
 *.exe
 local
 docs/scraper/__pycache__/

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -217,7 +217,7 @@ func ExportProject(
 	if err != nil {
 		var err1 error = nil
 		if os.IsNotExist(err) {
-			err1 = os.MkdirAll(dataPath, 0666)
+			err1 = os.MkdirAll(dataPath, 0755)
 		}
 		if err1 != nil {
 			return WrapErrorf(

--- a/regolith/file_protection.go
+++ b/regolith/file_protection.go
@@ -43,7 +43,7 @@ func (f *EditedFiles) Dump(dotRegolithPath string) error {
 	// Create parent directory of EditedFilesPath
 	efp := filepath.Join(dotRegolithPath, EditedFilesPath)
 	parentDir := filepath.Dir(efp)
-	err = os.MkdirAll(parentDir, 0666)
+	err = os.MkdirAll(parentDir, 0755)
 	if err != nil {
 		return WrapErrorf(err, osMkdirError, parentDir)
 	}

--- a/regolith/file_protection.go
+++ b/regolith/file_protection.go
@@ -47,7 +47,7 @@ func (f *EditedFiles) Dump(dotRegolithPath string) error {
 	if err != nil {
 		return WrapErrorf(err, osMkdirError, parentDir)
 	}
-	err = os.WriteFile(efp, result, 0666)
+	err = os.WriteFile(efp, result, 0644)
 	if err != nil {
 		return WrapErrorf(err, fileWriteError, efp)
 	}

--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -388,7 +388,7 @@ func (i *RemoteFilterDefinition) SaveVerssionInfo(version, dotRegolithPath strin
 	filterJsonMap["version"] = version
 	filterJson, _ := json.MarshalIndent(filterJsonMap, "", "\t") // no error
 	filterJsonPath := path.Join(i.GetDownloadPath(dotRegolithPath), "filter.json")
-	err = os.WriteFile(filterJsonPath, filterJson, 0666)
+	err = os.WriteFile(filterJsonPath, filterJson, 0644)
 	if err != nil {
 		return WrapErrorf(
 			err, "Unable to write \"filter.json\" for %q filter.", i.Id)

--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -242,7 +242,7 @@ func (f *RemoteFilterDefinition) CopyFilterData(dataPath string, dotRegolithPath
 				"filter.", f.Id, localDataPath)
 	} else if _, err := os.Stat(remoteDataPath); err == nil {
 		// Ensure folder exists
-		err = os.MkdirAll(localDataPath, 0666)
+		err = os.MkdirAll(localDataPath, 0755)
 		if err != nil {
 			Logger.Error("Could not create filter data folder.", err)
 		}

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -112,7 +112,7 @@ func Install(filters []string, force, debug bool) error {
 	}
 	// Save the config file
 	jsonBytes, _ := json.MarshalIndent(config, "", "  ")
-	err = ioutil.WriteFile(ConfigFilePath, jsonBytes, 0666)
+	err = ioutil.WriteFile(ConfigFilePath, jsonBytes, 0644)
 	if err != nil {
 		return WrapErrorf(
 			err,
@@ -350,7 +350,7 @@ func Init(debug bool) error {
 				"directory.\n\"regolith init\" can be used only in empty "+
 				"directories.", wd)
 	}
-	ioutil.WriteFile(".gitignore", []byte(GitIgnore), 0666)
+	ioutil.WriteFile(".gitignore", []byte(GitIgnore), 0644)
 	// Create new default configuration
 	jsonData := Config{
 		Name:   "Project name",
@@ -376,7 +376,7 @@ func Init(debug bool) error {
 		},
 	}
 	jsonBytes, _ := json.MarshalIndent(jsonData, "", "  ")
-	err = ioutil.WriteFile(ConfigFilePath, jsonBytes, 0666)
+	err = ioutil.WriteFile(ConfigFilePath, jsonBytes, 0644)
 	if err != nil {
 		return WrapErrorf(err, "Failed to write data to %q", ConfigFilePath)
 	}
@@ -413,12 +413,6 @@ func clean(cachedStatesOnly bool, dotRegolithPath string) error {
 		if err != nil {
 			return WrapErrorf(err, "failed to remove %q folder", dotRegolithPath)
 		}
-		// if leaveEmptyPath {
-		// 	err = os.MkdirAll(dotRegolithPath, 0666)
-		// 	if err != nil {
-		// 		return WrapErrorf(err, "failed to recreate %q folder", dotRegolithPath)
-		// 	}
-		// }
 	}
 
 	return nil
@@ -568,7 +562,7 @@ func Unlock(debug bool) error {
 				"If you want to make a new one. Please remove the file manually.\n"+
 				"The lock file is located at:\n%s", lockfilePath)
 	}
-	err = ioutil.WriteFile(lockfilePath, []byte(id), 0666)
+	err = ioutil.WriteFile(lockfilePath, []byte(id), 0644)
 	if err != nil {
 		return WrapError(err, "Failed to write lock file.")
 	}

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -15,7 +15,9 @@ import (
 // <filter-url>==<filter-version> or <filter-url>.
 // "filter-url" is the URL of the filter to install.
 // "filter-version" is the version of the filter. It can be semver, git commit
-//  hash, "HEAD", or "latest". "HEAD" means that the filter will be
+//
+//	hash, "HEAD", or "latest". "HEAD" means that the filter will be
+//
 // updated to lastest SHA commit and "latest" updates the filter to the latest
 // version tag. If "filter-version" is not specified, the filter will be
 // installed with the latest version or HEAD if there is no valid version tags.
@@ -388,7 +390,7 @@ func Init(debug bool) error {
 		filepath.Join(".regolith", "cache/venvs"),
 	}
 	for _, folder := range ConfigurationFolders {
-		err = os.MkdirAll(folder, 0666)
+		err = os.MkdirAll(folder, 0755)
 		if err != nil {
 			Logger.Error("Could not create folder: %s", folder, err)
 		}
@@ -496,7 +498,7 @@ func CleanUserCache() error {
 	if err != nil {
 		return WrapErrorf(err, "failed to remove %q folder", regolithCacheFiles)
 	}
-	os.MkdirAll(regolithCacheFiles, 0666)
+	os.MkdirAll(regolithCacheFiles, 0755)
 	Logger.Infof("All regolith files cached in user app data cleaned.")
 	return nil
 }

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -15,9 +15,7 @@ import (
 // <filter-url>==<filter-version> or <filter-url>.
 // "filter-url" is the URL of the filter to install.
 // "filter-version" is the version of the filter. It can be semver, git commit
-//
-//	hash, "HEAD", or "latest". "HEAD" means that the filter will be
-//
+// hash, "HEAD", or "latest". "HEAD" means that the filter will be
 // updated to lastest SHA commit and "latest" updates the filter to the latest
 // version tag. If "filter-version" is not specified, the filter will be
 // installed with the latest version or HEAD if there is no valid version tags.

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -17,7 +17,7 @@ import (
 func RecycledSetupTmpFiles(config Config, profile Profile, dotRegolithPath string) error {
 	start := time.Now()
 	tmpPath := filepath.Join(dotRegolithPath, "tmp")
-	err := os.MkdirAll(tmpPath, 0666)
+	err := os.MkdirAll(tmpPath, 0755)
 	if err != nil {
 		return WrapErrorf(err, osMkdirError, tmpPath)
 	}
@@ -84,7 +84,7 @@ func SetupTmpFiles(config Config, profile Profile, dotRegolithPath string) error
 		return WrapErrorf(err, osRemoveError, tmpPath)
 	}
 
-	err = os.MkdirAll(tmpPath, 0666)
+	err = os.MkdirAll(tmpPath, 0755)
 	if err != nil {
 		return WrapErrorf(err, osMkdirError, tmpPath)
 	}
@@ -103,7 +103,7 @@ func SetupTmpFiles(config Config, profile Profile, dotRegolithPath string) error
 				if os.IsNotExist(err) {
 					Logger.Warnf(
 						"%s %q does not exist", descriptiveName, path)
-					err = os.MkdirAll(p, 0666)
+					err = os.MkdirAll(p, 0755)
 					if err != nil {
 						return WrapErrorf(err, osMkdirError, p)
 					}
@@ -120,7 +120,7 @@ func SetupTmpFiles(config Config, profile Profile, dotRegolithPath string) error
 				return WrappedErrorf(isDirNotADirError, path)
 			}
 		} else {
-			err = os.MkdirAll(p, 0666)
+			err = os.MkdirAll(p, 0755)
 			if err != nil {
 				return WrapErrorf(err, osMkdirError, p)
 			}

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -143,7 +143,7 @@ func WrapErrorf(err error, text string, args ...interface{}) error {
 
 func CreateDirectoryIfNotExists(directory string, mustSucceed bool) error {
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
-		err = os.MkdirAll(directory, 0666)
+		err = os.MkdirAll(directory, 0755)
 		if err != nil {
 			if mustSucceed {
 				// Error outside of this function should tell about the path

--- a/test/file_protection_test.go
+++ b/test/file_protection_test.go
@@ -33,7 +33,7 @@ func testSwitchingExportTargets(t *testing.T, recycled bool) {
 	defer os.RemoveAll(tmpDir)
 	defer os.Chdir(wd)
 	workingDir := filepath.Join(tmpDir, "working-dir")
-	os.Mkdir(workingDir, 0666)
+	os.Mkdir(workingDir, 0755)
 	// Copy the test project to the working directory
 	err = copy.Copy(
 		multitargetProjectPath,
@@ -97,7 +97,7 @@ func testTriggerFileProtection(t *testing.T, recycled bool) {
 	defer os.RemoveAll(tmpDir)
 	defer os.Chdir(wd)
 	workingDir := filepath.Join(tmpDir, "working-dir")
-	os.Mkdir(workingDir, 0666)
+	os.Mkdir(workingDir, 0755)
 	// Copy the test project to the working directory
 	err = copy.Copy(
 		multitargetProjectPath,

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -70,7 +70,7 @@ func testRegolithRunMissingRp(t *testing.T, recycled bool) {
 	// Before deleting "workingDir" the test must stop using it
 	defer os.RemoveAll(tmpDir)
 	defer os.Chdir(wd)
-	os.Mkdir(tmpDir, 0666)
+	os.Mkdir(tmpDir, 0755)
 	// Copy the test project to the working directory
 	err = copy.Copy(
 		runMissingRpProjectPath,

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -38,7 +38,7 @@ func TestInstallAllUnlockAndRun(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	defer os.Chdir(wd)
 	workingDir := filepath.Join(tmpDir, "working-dir")
-	os.Mkdir(workingDir, 0666)
+	os.Mkdir(workingDir, 0755)
 	// Copy the test project to the working directory
 	err = copy.Copy(
 		versionedRemoteFilterProject,


### PR DESCRIPTION
Hello everyone,

I've tried running regolith on linux as I am currently trying to get a development workflow to work on linux.
regolith is unfortunately unable to create folders within folders as the permissions `0666` don't allow anyone to create folders in the freshly created folder. To mitigate that I've modified the permission set to be `0755` (rwx r-x r-x) as this is the default permission for new created folders on Manjaro Linux. 

.gitignore was modified to exclude my build folder `bin/`.

Best regards
Timo
