### PR TITLE
Fix for issue #222

### DIFF
--- a/docs/_pages/docs/filter_types/nim-filters.md
+++ b/docs/_pages/docs/filter_types/nim-filters.md
@@ -23,11 +23,17 @@ The syntax for running a nim filter is this:
 ```json
 {
   "runWith": "nim",
-  "script": "./filters/example.nim"
+  "script": "./filters/example.nim",
+
+  // Optional property that defines the path to the folder with the *.nimble file
+  "requirements": "./filters"
 }
 ```
 
 ## Requirements and Dependencies
 
-If your filter has dependencies, put a `.nimble` file in the same directory as your `.nim` file.
+If your filter has dependencies, put a `.nimble` file in the same directory as your `.nim` file, alternatively
+you can specify different path using the "requirements" property. Regolith will look for the nimble file in
+the folder specified by "requirements" or if it's not defined in the same folder as the script.
+
 Documentation on how to make a `.nimble` file is located [here](https://github.com/nim-lang/nimble#creating-packages).

--- a/docs/_pages/docs/filter_types/nodejs-filters.md
+++ b/docs/_pages/docs/filter_types/nodejs-filters.md
@@ -20,12 +20,16 @@ The syntax for running a nodejs filter is this:
 ```json
 {
   "runWith": "nodejs",
-  "script": "./filters/example.js"
+  "script": "./filters/example.js",
+
+  // Optional property that defines the path to the folder with the package.json file
+  "requirements": "./filters"
 }
 ```
 
 ## Requirements and Dependencies
 
-When installing, regolith will check for a `package.json` file at the top level of the filter folder.
+When installing, regolith will check for a `package.json` file. If requirements property is specified
+reqolith will look in that folder, otherwise it will look in the folder with the script.
 
 When developing a Node filter with dependencies, you must create this file. You can create a `package.json` file yourself by using `npm init`.

--- a/docs/_pages/docs/filter_types/python-filters.md
+++ b/docs/_pages/docs/filter_types/python-filters.md
@@ -41,7 +41,7 @@ The syntax for running a python script is this:
 When installing, regolith will check for a `requirements.txt` file. Regolith will look for the requirements file in
 the path defined by the "requirements" property or if it's not specified, in the folder with the script.
 
-If `reqirements.txt` file exits, Regolith will attempt to install these dependencies into a venv, as described bellow.
+If `reqirements.txt` file exits, Regolith will attempt to install these dependencies into a venv, as described below.
 
 When developing a python filter with dependencies, you must create this file. You can create a `requirements.txt` file yourself by using `pip freeze`. 
 

--- a/docs/_pages/docs/filter_types/python-filters.md
+++ b/docs/_pages/docs/filter_types/python-filters.md
@@ -32,14 +32,16 @@ The syntax for running a python script is this:
   "script": "./filters/example.py",
 
   // Optional property that defines the folder where regolith should look for the requriements.txt file
-  "requirements": "./filters
+  "requirements": "./filters/requirements.txt
 }
 ```
 
 ## Requirements and Dependencies
 
 When installing, regolith will check for a `requirements.txt` file. Regolith will look for the requirements file in
-the path defined by the "requirements" property or if it's not specified, in the folder with the script.
+the path defined by the "requirements" property or if it's not specified, Regolith will look for the `requirements.txt`
+file in the same folder as the script.
+
 
 If `reqirements.txt` file exits, Regolith will attempt to install these dependencies into a venv, as described below.
 

--- a/docs/_pages/docs/filter_types/python-filters.md
+++ b/docs/_pages/docs/filter_types/python-filters.md
@@ -31,21 +31,19 @@ The syntax for running a python script is this:
   "runWith": "python",
   "script": "./filters/example.py",
 
-  // Optional property that defines the folder where regolith should look for the requriements.txt file
+  // Optional property that defines the path to the file with the requirements
   "requirements": "./filters/requirements.txt
 }
 ```
 
 ## Requirements and Dependencies
 
-When installing, regolith will check for a `requirements.txt` file. Regolith will look for the requirements file in
-the path defined by the "requirements" property or if it's not specified, Regolith will look for the `requirements.txt`
-file in the same folder as the script.
+When installing, Regolith will check if the filter has any requirements. If the "requirements" property is set,
+Regolith will use the file specified in the property to install the dependencies. If the property is not set,
+Regolith will look for a file named "requirements.txt" in the same directory as the script.
+If requirements file exits, Regolith will attempt to install these dependencies into a venv, as described below.
 
-
-If `reqirements.txt` file exits, Regolith will attempt to install these dependencies into a venv, as described below.
-
-When developing a python filter with dependencies, you must create this file. You can create a `requirements.txt` file yourself by using `pip freeze`. 
+When developing a Python filter with dependencies, you must create this file. You can create a `requirements.txt` file yourself by using `pip freeze`. 
 
 ## Venv Handling
 

--- a/docs/_pages/docs/filter_types/python-filters.md
+++ b/docs/_pages/docs/filter_types/python-filters.md
@@ -29,13 +29,19 @@ The syntax for running a python script is this:
 ```json
 {
   "runWith": "python",
-  "script": "./filters/example.py"
+  "script": "./filters/example.py",
+
+  // Optional property that defines the folder where regolith should look for the requriements.txt file
+  "requirements": "./filters
 }
 ```
 
 ## Requirements and Dependencies
 
-When installing, regolith will check for a `requirements.txt` file at the top level of the filter folder. It will attempt to install these dependencies into a venv, as described bellow.
+When installing, regolith will check for a `requirements.txt` file. Regolith will look for the requirements file in
+the path defined by the "requirements" property or if it's not specified, in the folder with the script.
+
+If `reqirements.txt` file exits, Regolith will attempt to install these dependencies into a venv, as described bellow.
 
 When developing a python filter with dependencies, you must create this file. You can create a `requirements.txt` file yourself by using `pip freeze`. 
 

--- a/regolith/filter_nim.go
+++ b/regolith/filter_nim.go
@@ -117,7 +117,6 @@ func (f *NimFilterDefinition) InstallDependencies(
 	Logger.Infof("Downloading dependencies for %s...", f.Id)
 	var requirementsPath string
 	if f.Requirements == "" {
-		Logger.Debug("Unable to find the requirements property, using the parent folder instead.")
 		// Deduce the path from the script path
 		joinedPath := filepath.Join(installLocation, f.Script)
 		scriptPath, err := filepath.Abs(joinedPath)

--- a/regolith/filter_nim.go
+++ b/regolith/filter_nim.go
@@ -11,6 +11,10 @@ import (
 type NimFilterDefinition struct {
 	FilterDefinition
 	Script string `json:"script,omitempty"`
+
+	// Requirements is an optional path to the folder with the nimble file. If not specified
+	// the parent of the script path is used instead.
+	Requirements string `json:"requirements,omitempty"`
 }
 
 type NimFilter struct {
@@ -32,6 +36,16 @@ func NimFilterDefinitionFromObject(
 			jsonPropertyTypeError, "script", "string")
 	}
 	filter.Script = script
+
+	requirementsObj, ok := obj["requirements"]
+	if ok {
+		requirements, ok := requirementsObj.(string)
+		if !ok {
+			return nil, WrappedErrorf(
+				jsonPropertyTypeError, "requirements", "string")
+		}
+		filter.Requirements = requirements
+	}
 	return filter, nil
 }
 
@@ -101,19 +115,32 @@ func (f *NimFilterDefinition) InstallDependencies(
 		installLocation = parent.GetDownloadPath(dotRegolithPath)
 	}
 	Logger.Infof("Downloading dependencies for %s...", f.Id)
-	joinedPath := filepath.Join(installLocation, f.Script)
-	scriptPath, err := filepath.Abs(joinedPath)
-	if err != nil {
-		return WrapErrorf(err, filepathAbsError, joinedPath)
+	var requirementsPath string
+	if f.Requirements == "" {
+		Logger.Debug("Unable to find the requirements property, using the parent folder instead.")
+		// Deduce the path from the script path
+		joinedPath := filepath.Join(installLocation, f.Script)
+		scriptPath, err := filepath.Abs(joinedPath)
+		if err != nil {
+			return WrapErrorf(err, filepathAbsError, joinedPath)
+		}
+		requirementsPath = filepath.Dir(scriptPath)
+	} else {
+		joinedPath := filepath.Join(installLocation, f.Requirements)
+		scriptPath, err := filepath.Abs(joinedPath)
+		if err != nil {
+			return WrapErrorf(err, filepathAbsError, joinedPath)
+		}
+		requirementsPath = scriptPath
 	}
-	filterPath := filepath.Dir(scriptPath)
-	if hasNimble(filterPath) {
+	Logger.Debugf("Installing dependencies using nimble in %s", requirementsPath)
+	if hasNimble(requirementsPath) {
 		Logger.Info("Installing nim dependencies...")
 		err := RunSubProcess(
-			"nimble", []string{"install --deps-only -y"}, filterPath, filterPath, ShortFilterName(f.Id))
+			"nimble", []string{"install", "-d", "-y"}, requirementsPath, requirementsPath, ShortFilterName(f.Id))
 		if err != nil {
 			return WrapErrorf(
-				err, "Failed to run nimble to install dependencies of a filter."+
+				err, "Failed to run nimble to install dependencies of a filter.\n"+
 					"Filter name: %s.",
 				f.Id)
 		}
@@ -146,7 +173,7 @@ func (f *NimFilter) Check(context RunContext) error {
 func hasNimble(filterPath string) bool {
 	nimble := false
 	filepath.Walk(filterPath, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
+		if err != nil || info.IsDir() {
 			return nil
 		}
 		if filepath.Ext(path) == ".nimble" {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -406,7 +406,7 @@ func Init(debug bool) error {
 	// Add the schema property, this is a little hacky
 	rawJsonData := make(map[string]interface{}, 0)
 	json.Unmarshal(jsonBytes, &rawJsonData)
-	rawJsonData["$schema"] = "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.json"
+	rawJsonData["$schema"] = "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json"
 	jsonBytes, _ = json.MarshalIndent(rawJsonData, "", "\t")
 
 	err = ioutil.WriteFile(ConfigFilePath, jsonBytes, 0644)

--- a/test/testdata/fresh_project/config.json
+++ b/test/testdata/fresh_project/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.json",
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json",
 	"author": "Your name",
 	"name": "Project name",
 	"packs": {

--- a/test/testdata/regolith_install/1.0.0/config.json
+++ b/test/testdata/regolith_install/1.0.0/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.json",
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json",
 	"author": "Your name",
 	"name": "Project name",
 	"packs": {

--- a/test/testdata/regolith_install/1.0.1/config.json
+++ b/test/testdata/regolith_install/1.0.1/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.json",
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json",
 	"author": "Your name",
 	"name": "Project name",
 	"packs": {

--- a/test/testdata/regolith_install/HEAD/config.json
+++ b/test/testdata/regolith_install/HEAD/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.json",
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json",
 	"author": "Your name",
 	"name": "Project name",
 	"packs": {

--- a/test/testdata/regolith_install/latest/config.json
+++ b/test/testdata/regolith_install/latest/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.json",
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json",
 	"author": "Your name",
 	"name": "Project name",
 	"packs": {

--- a/test/testdata/regolith_install/sha/config.json
+++ b/test/testdata/regolith_install/sha/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.json",
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json",
 	"author": "Your name",
 	"name": "Project name",
 	"packs": {

--- a/test/testdata/regolith_install/tag/config.json
+++ b/test/testdata/regolith_install/tag/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.json",
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json",
 	"author": "Your name",
 	"name": "Project name",
 	"packs": {


### PR DESCRIPTION
This PR will fix issue #222. Some of the filters will get new "requirements" field that lets
the user (filter developer) define the path to the path/file with requirements.

Affected filters:
- `nim` - the path should lead to a **folder** with the `*.nimble` file. Nim filter also has some additional fixes.
- `python` - path to the requirements.txt **file**
- `nodejs`
