### PR TITLE
Fix community filters docs links

### DIFF
--- a/docs/docs/community-filters.md
+++ b/docs/docs/community-filters.md
@@ -25,43 +25,44 @@ Having trouble? You can learn more about online filters [here](/guide/online-fil
 
 | Name | Author | Language | Description |
 | ---- | ------ | -------- | ----------- |
-| [esbuild_executor](https://github.com/MajestikButter/Regolith-Filters/blob/main/esbuild_executor/filter.json) | MajestikButter | nodejs | A regolith filter for using esbuild |
-| [js_formatter](https://github.com/MajestikButter/Regolith-Filters/blob/main/js_formatter/filter.json) | MajestikButter | nodejs | A regolith filter for formatting JavaScript files |
-| [json_formatter](https://github.com/MajestikButter/Regolith-Filters/blob/main/json_formatter/filter.json) | MajestikButter | nodejs | A regolith filter for formatting JSON files |
-| [ts_transpiler](https://github.com/MajestikButter/Regolith-Filters/blob/main/ts_transpiler/filter.json) | MajestikButter | nodejs | A regolith filter for transpiling Typescript files |
-| [NBTEnchant](https://github.com/SmokeyStack/MCScripts/blob/main/NBTEnchant/filter.json) | SmokeyStack | python | This script is used to generate .mcstructure files containing edited nbt data that is currently not possible to do ingame |
-| [file_freedom](https://github.com/Hatchibombotar/useful-regolith-filters/blob/main/file_freedom/filter.json) | Hatchibombotar | nodejs | This filter allows you to place bedrock addon file *anywhere* within the addon directories.  |
-| [functioner](https://github.com/Hatchibombotar/useful-regolith-filters/blob/main/functioner/filter.json) | Hatchibombotar | nodejs | A filter for regolith that adds more syntax to function files. |
-| [init-full](https://github.com/Hatchibombotar/useful-regolith-filters/blob/main/init-full/filter.json) | Hatchibombotar | nodejs | Filter that creates bedrock manifest files on install |
-| [link_manifests](https://github.com/Hatchibombotar/useful-regolith-filters/blob/main/link_manifests/filter.json) | Hatchibombotar | nodejs | Links uuid's from the resource and behaviour pack manifests in the dependencies section. |
-| [molang_insert](https://github.com/Hatchibombotar/useful-regolith-filters/blob/main/molang_insert/filter.json) | Hatchibombotar | nodejs | A filter for regolith that allows you to insert molang. |
-| [pack_commons](https://github.com/Hatchibombotar/useful-regolith-filters/blob/main/pack_commons/filter.json) | Hatchibombotar | nodejs | Intended to allow copying of files into both the resource and behaviour packs |
-| [simple_blocks](https://github.com/Hatchibombotar/useful-regolith-filters/blob/main/simple_blocks/filter.json) | Hatchibombotar | nodejs | A filter that creates blocks from one file. |
-| [templater](https://github.com/Hatchibombotar/useful-regolith-filters/blob/main/templater/filter.json) | Hatchibombotar | nodejs | A templater filter for regolith. |
-| [item_scale](https://github.com/MedicalJewel105/regolilters/blob/main/item_scale/filter.json) | MedicalJewel105 | python | This filter generates render_offsets for 1.16.100+ items. |
-| [custom_project](https://github.com/Nusiq/regolith-filters/blob/master/custom_project/filter.json) | Nusiq | exe | No description. |
-| [debug_say_function_name](https://github.com/Nusiq/regolith-filters/blob/master/debug_say_function_name/filter.json) | Nusiq | python | No description. |
-| [pytemplate](https://github.com/Nusiq/regolith-filters/blob/master/pytemplate/filter.json) | Nusiq | python | No description. |
-| [run_counter](https://github.com/Nusiq/regolith-filters/blob/master/run_counter/filter.json) | Nusiq | python | A pointless filter for counting the number of uses of the 'regolith run' command. |
-| [subfunctions](https://github.com/Nusiq/regolith-filters/blob/master/subfunctions/filter.json) | Nusiq | python | No description. |
-| [system_template](https://github.com/Nusiq/regolith-filters/blob/master/system_template/filter.json) | Nusiq | python | No description. |
-| [extend-vanilla-entities](https://github.com/littlechestnutgames/regolith-filters/blob/main/extend-vanilla-entities/filter.json) | littlechestnutgames | python | A JSON partials system. |
-| [digger_gen](https://github.com/SirLich/regolith-filters/blob/main/digger_gen/filter.json) | SirLich | python | The `digger_gen` filter allows you to quickly and easily generate the `minecraft:digger` component, to satisfy your tool-building needs. |
-| [e-backup](https://github.com/cda94581/regolith-filters/blob/main/e-backup/filter.json) | cda94581 | nodejs | Backups your export target in case you made a mistake. |
-| [export](https://github.com/cda94581/regolith-filters/blob/main/export/filter.json) | cda94581 | nodejs | Exports your add-on into a ".mcaddon" automatically. |
-| [minimize](https://github.com/cda94581/regolith-filters/blob/main/minimize/filter.json) | cda94581 | nodejs | Minimize all file JSONs. Can save a tiny bit of space. Also kinda pointless but whatever. |
-| [namespace](https://github.com/cda94581/regolith-filters/blob/main/namespace/filter.json) | cda94581 | nodejs | Automatically apply and replace namespaces to each block, item, entity, recipe, attachable, particle, and fog. Useful for temporary namespaces before deployment. |
-| [module_importer](https://github.com/ShiCheng-Lu/Regolith-Filters/blob/main/module_importer/filter.json) | ShiCheng-Lu | nodejs | A regolith filter for import |
-| [command_lang](https://github.com/MCDevKit/regolith-library/blob/main/command_lang/filter.json) | MCDevKit | shell | Compiles the CommandLang programming language into .mcfunction files. |
-| [json_templating_engine](https://github.com/MCDevKit/regolith-library/blob/main/json_templating_engine/filter.json) | MCDevKit | java | Compiles JSON templates into JSON files. Especially useful for making reusable pieces of content or large amounts of JSON files. |
-| [jsonte](https://github.com/MCDevKit/regolith-library/blob/main/jsonte/filter.json) | MCDevKit | exe | No description. |
-| [classes](https://github.com/evilguy50/my-regolith-filters/blob/main/classes/filter.json) | evilguy50 | nim | filter for adding OOP class like structure to functions |
-| [dash](https://github.com/evilguy50/my-regolith-filters/blob/main/dash/filter.json) | evilguy50 | nim | No description. |
-| [ds_store](https://github.com/evilguy50/my-regolith-filters/blob/main/ds_store/filter.json) | evilguy50 | nim | filter for removing .DS_Store files |
-| [new_exec](https://github.com/evilguy50/my-regolith-filters/blob/main/new_exec/filter.json) | evilguy50 | nodejs | filter for converting old execute commands to the 1.19.10 format |
-| [shorthand](https://github.com/evilguy50/my-regolith-filters/blob/main/shorthand/filter.json) | evilguy50 | python | filter for having shorthand syntax inside of functions |
-| [strip](https://github.com/evilguy50/my-regolith-filters/blob/main/strip/filter.json) | evilguy50 | nim | filter for striping comments from json, mcfunction, and lang files |
-| [style_lint](https://github.com/evilguy50/my-regolith-filters/blob/main/style_lint/filter.json) | evilguy50 | python | filter for automatic project styling |
-| [title_ui](https://github.com/evilguy50/my-regolith-filters/blob/main/title_ui/filter.json) | evilguy50 | nim | filter for generating title ui bindings |
-| [echo](https://github.com/SirLich/echo-npc-regolith/blob/main/echo/filter.json) | SirLich | python | No description. |
-| [scalable-teams](https://github.com/cda94581/regolith-premade-addons/blob/main/scalable-teams/filter.json) | cda94581 | nodejs | Generates a pre-made teams add-on, scalable and customizable. Appends itself to developed packs. |
+| [esbuild_executor](https://github.com/MajestikButter/Regolith-Filters/tree/main/esbuild_executor) | MajestikButter | nodejs | A regolith filter for using esbuild |
+| [js_formatter](https://github.com/MajestikButter/Regolith-Filters/tree/main/js_formatter) | MajestikButter | nodejs | A regolith filter for formatting JavaScript files |
+| [json_formatter](https://github.com/MajestikButter/Regolith-Filters/tree/main/json_formatter) | MajestikButter | nodejs | A regolith filter for formatting JSON files |
+| [ts_transpiler](https://github.com/MajestikButter/Regolith-Filters/tree/main/ts_transpiler) | MajestikButter | nodejs | A regolith filter for transpiling Typescript files |
+| [NBTEnchant](https://github.com/SmokeyStack/MCScripts/tree/main/NBTEnchant) | SmokeyStack | python | This script is used to generate .mcstructure files containing edited nbt data that is currently not possible to do ingame |
+| [file_freedom](https://github.com/Hatchibombotar/useful-regolith-filters/tree/main/file_freedom) | Hatchibombotar | nodejs | This filter allows you to place bedrock addon file *anywhere* within the addon directories.  |
+| [functioner](https://github.com/Hatchibombotar/useful-regolith-filters/tree/main/functioner) | Hatchibombotar | nodejs | A filter for regolith that adds more syntax to function files. |
+| [init-full](https://github.com/Hatchibombotar/useful-regolith-filters/tree/main/init-full) | Hatchibombotar | nodejs | Filter that creates bedrock manifest files on install |
+| [link_manifests](https://github.com/Hatchibombotar/useful-regolith-filters/tree/main/link_manifests) | Hatchibombotar | nodejs | Links uuid's from the resource and behaviour pack manifests in the dependencies section. |
+| [molang_insert](https://github.com/Hatchibombotar/useful-regolith-filters/tree/main/molang_insert) | Hatchibombotar | nodejs | A filter for regolith that allows you to insert molang. |
+| [pack_commons](https://github.com/Hatchibombotar/useful-regolith-filters/tree/main/pack_commons) | Hatchibombotar | nodejs | Intended to allow copying of files into both the resource and behaviour packs |
+| [simple_blocks](https://github.com/Hatchibombotar/useful-regolith-filters/tree/main/simple_blocks) | Hatchibombotar | nodejs | A filter that creates blocks from one file. |
+| [templater](https://github.com/Hatchibombotar/useful-regolith-filters/tree/main/templater) | Hatchibombotar | nodejs | A templater filter for regolith. |
+| [item_scale](https://github.com/MedicalJewel105/regolilters/tree/main/item_scale) | MedicalJewel105 | python | This filter generates render_offsets for 1.16.100+ items. |
+| [custom_project](https://github.com/Nusiq/regolith-filters/tree/master/custom_project) | Nusiq | exe | No description. |
+| [debug_say_function_name](https://github.com/Nusiq/regolith-filters/tree/master/debug_say_function_name) | Nusiq | python | No description. |
+| [pytemplate](https://github.com/Nusiq/regolith-filters/tree/master/pytemplate) | Nusiq | python | No description. |
+| [run_counter](https://github.com/Nusiq/regolith-filters/tree/master/run_counter) | Nusiq | python | A pointless filter for counting the number of uses of the 'regolith run' command. |
+| [subfunctions](https://github.com/Nusiq/regolith-filters/tree/master/subfunctions) | Nusiq | python | No description. |
+| [system_template](https://github.com/Nusiq/regolith-filters/tree/master/system_template) | Nusiq | python | No description. |
+| [extend-vanilla-entities](https://github.com/littlechestnutgames/regolith-filters/tree/main/extend-vanilla-entities) | littlechestnutgames | python | A JSON partials system. |
+| [digger_gen](https://github.com/SirLich/regolith-filters/tree/main/digger_gen) | SirLich | python | The `digger_gen` filter allows you to quickly and easily generate the `minecraft:digger` component, to satisfy your tool-building needs. |
+| [e-backup](https://github.com/cda94581/regolith-filters/tree/main/e-backup) | cda94581 | nodejs | Backups your export target in case you made a mistake. |
+| [export](https://github.com/cda94581/regolith-filters/tree/main/export) | cda94581 | nodejs | Exports your add-on into a ".mcaddon" automatically. |
+| [minimize](https://github.com/cda94581/regolith-filters/tree/main/minimize) | cda94581 | nodejs | Minimize all file JSONs. Can save a tiny bit of space. Also kinda pointless but whatever. |
+| [namespace](https://github.com/cda94581/regolith-filters/tree/main/namespace) | cda94581 | nodejs | Automatically apply and replace namespaces to each block, item, entity, recipe, attachable, particle, and fog. Useful for temporary namespaces before deployment. |
+| [export](https://github.com/Makercamp-SRLs/Regolith-filters/tree/main/export) | Makercamp-SRLs | nodejs | Exports your add-on into a ".mcaddon", ".mcworld", ".mctemplate" automatically. |
+| [module_importer](https://github.com/ShiCheng-Lu/Regolith-Filters/tree/main/module_importer) | ShiCheng-Lu | nodejs | A regolith filter for import |
+| [command_lang](https://github.com/MCDevKit/regolith-library/tree/main/command_lang) | MCDevKit | shell | Compiles the CommandLang programming language into .mcfunction files. |
+| [json_templating_engine](https://github.com/MCDevKit/regolith-library/tree/main/json_templating_engine) | MCDevKit | java | Compiles JSON templates into JSON files. Especially useful for making reusable pieces of content or large amounts of JSON files. |
+| [jsonte](https://github.com/MCDevKit/regolith-library/tree/main/jsonte) | MCDevKit | exe | No description. |
+| [classes](https://github.com/evilguy50/my-regolith-filters/tree/main/classes) | evilguy50 | nim | filter for adding OOP class like structure to functions |
+| [dash](https://github.com/evilguy50/my-regolith-filters/tree/main/dash) | evilguy50 | nim | No description. |
+| [ds_store](https://github.com/evilguy50/my-regolith-filters/tree/main/ds_store) | evilguy50 | nim | filter for removing .DS_Store files |
+| [new_exec](https://github.com/evilguy50/my-regolith-filters/tree/main/new_exec) | evilguy50 | nodejs | filter for converting old execute commands to the 1.19.10 format |
+| [shorthand](https://github.com/evilguy50/my-regolith-filters/tree/main/shorthand) | evilguy50 | python | filter for having shorthand syntax inside of functions |
+| [strip](https://github.com/evilguy50/my-regolith-filters/tree/main/strip) | evilguy50 | nim | filter for striping comments from json, mcfunction, and lang files |
+| [style_lint](https://github.com/evilguy50/my-regolith-filters/tree/main/style_lint) | evilguy50 | python | filter for automatic project styling |
+| [title_ui](https://github.com/evilguy50/my-regolith-filters/tree/main/title_ui) | evilguy50 | nim | filter for generating title ui bindings |
+| [echo](https://github.com/SirLich/echo-npc-regolith/tree/main/echo) | SirLich | python | No description. |
+| [scalable-teams](https://github.com/cda94581/regolith-premade-addons/tree/main/scalable-teams) | cda94581 | nodejs | Generates a pre-made teams add-on, scalable and customizable. Appends itself to developed packs. |

--- a/docs/fetch-filters.ts
+++ b/docs/fetch-filters.ts
@@ -161,7 +161,7 @@ async function writeCommunityFilters(): Promise<void> {
 
                 name = rootItem.name
                 lang = filter.filters[0].runWith
-                url = childItem.html_url
+                url = rootItem.html_url
                 description =
                   filter?.filters[0]?.description ||
                   filter?.description ||


### PR DESCRIPTION
Right now, clicking in any of the community filters links on the docs takes you to the `filter.json` file instead of filter's directory. This PR fixes that.