### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/regolith/config_unparsed.go
+++ b/regolith/config_unparsed.go
@@ -6,7 +6,7 @@
 package regolith
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
 
@@ -15,7 +15,7 @@ import (
 
 // LoadConfigAsMap loads the config.json file as map[string]interface{}
 func LoadConfigAsMap() (map[string]interface{}, error) {
-	file, err := ioutil.ReadFile(ConfigFilePath)
+	file, err := os.ReadFile(ConfigFilePath)
 	if err != nil {
 		return nil, burrito.WrappedError( // We don't need to pass OS error. It's confusing.
 			"Failed to open \"config.json\". This directory is not a Regolith project.\n" +

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -688,7 +687,7 @@ func move(source, destination string) error {
 			return burrito.WrapErrorf(err, isDirEmptyNotEmptyError, destination)
 		}
 		// Move all files in source to destination
-		files, err := ioutil.ReadDir(source)
+		files, err := os.ReadDir(source)
 		movedFiles := make([][2]string, 0, 100)
 		movingFailed := false
 		var errMoving error

--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -3,7 +3,6 @@ package regolith
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -142,7 +141,7 @@ func (f *RemoteFilterDefinition) CreateFilterRunner(runConfiguration map[string]
 // (f *RemoteFilter) SubfilterCollection()
 func (f *RemoteFilterDefinition) InstallDependencies(_ *RemoteFilterDefinition, dotRegolithPath string) error {
 	path := filepath.Join(f.GetDownloadPath(dotRegolithPath), "filter.json")
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 
 	if err != nil {
 		return burrito.WrapErrorf(err, fileReadError, path)
@@ -283,7 +282,7 @@ func (f *RemoteFilter) IsCached(dotRegolithPath string) bool {
 // GetCachedVersion returns cached version of the remote filter.
 func (f *RemoteFilter) GetCachedVersion(dotRegolithPath string) (*string, error) {
 	path := filepath.Join(f.GetDownloadPath(dotRegolithPath), "filter.json")
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, burrito.WrapErrorf(err, fileReadError, path)
@@ -310,7 +309,7 @@ func (f *RemoteFilter) GetCachedVersion(dotRegolithPath string) (*string, error)
 func (f *RemoteFilter) IsUsingDataExport(dotRegolithPath string) (bool, error) {
 	// Load the filter.json file
 	filterJsonPath := filepath.Join(f.GetDownloadPath(dotRegolithPath), "filter.json")
-	file, err := ioutil.ReadFile(filterJsonPath)
+	file, err := os.ReadFile(filterJsonPath)
 	if err != nil {
 		return false, burrito.WrappedErrorf(readFilterJsonError, filterJsonPath)
 	}
@@ -430,7 +429,7 @@ func (i *RemoteFilterDefinition) SaveVerssionInfo(version, dotRegolithPath strin
 func (f *RemoteFilterDefinition) LoadFilterJson(dotRegolithPath string) (map[string]interface{}, error) {
 	downloadPath := f.GetDownloadPath(dotRegolithPath)
 	filterJsonPath := path.Join(downloadPath, "filter.json")
-	filterJson, err1 := ioutil.ReadFile(filterJsonPath)
+	filterJson, err1 := os.ReadFile(filterJsonPath)
 	var filterJsonMap map[string]interface{}
 	err2 := json.Unmarshal(filterJson, &filterJsonMap)
 	if err := firstErr(err1, err2); err != nil {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -3,7 +3,6 @@ package regolith
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -117,7 +116,7 @@ func Install(filters []string, force, debug bool) error {
 	}
 	// Save the config file
 	jsonBytes, _ := json.MarshalIndent(config, "", "\t")
-	err = ioutil.WriteFile(ConfigFilePath, jsonBytes, 0644)
+	err = os.WriteFile(ConfigFilePath, jsonBytes, 0644)
 	if err != nil {
 		return burrito.WrapErrorf(
 			err,
@@ -373,7 +372,7 @@ func Init(debug bool) error {
 				"directory.\n\"regolith init\" can be used only in empty "+
 				"directories.", wd)
 	}
-	ioutil.WriteFile(".gitignore", []byte(GitIgnore), 0644)
+	os.WriteFile(".gitignore", []byte(GitIgnore), 0644)
 	// Create new default configuration
 	userConfig, err := getCombinedUserConfig()
 	if err != nil {
@@ -409,7 +408,7 @@ func Init(debug bool) error {
 	rawJsonData["$schema"] = "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.1.json"
 	jsonBytes, _ = json.MarshalIndent(rawJsonData, "", "\t")
 
-	err = ioutil.WriteFile(ConfigFilePath, jsonBytes, 0644)
+	err = os.WriteFile(ConfigFilePath, jsonBytes, 0644)
 	if err != nil {
 		return burrito.WrapErrorf(err, "Failed to write data to %q", ConfigFilePath)
 	}

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -3,7 +3,6 @@ package regolith
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -189,7 +188,7 @@ func RunProfileImpl(context RunContext) (bool, error) {
 func (f *RemoteFilter) subfilterCollection(dotRegolithPath string) (*FilterCollection, error) {
 	path := filepath.Join(f.GetDownloadPath(dotRegolithPath), "filter.json")
 	result := &FilterCollection{Filters: []FilterRunner{}}
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, burrito.WrappedErrorf(readFilterJsonError, path)

--- a/regolith/resolver.go
+++ b/regolith/resolver.go
@@ -3,7 +3,6 @@ package regolith
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,7 +112,7 @@ func DownloadResolverMaps() error {
 			}
 			// Add "url" property to the resolver file
 			fileData := make(map[string]interface{})
-			f, err := ioutil.ReadFile(savePath)
+			f, err := os.ReadFile(savePath)
 			if err != nil {
 				return burrito.WrapErrorf(err, fileReadError, savePath)
 			}
@@ -124,7 +123,7 @@ func DownloadResolverMaps() error {
 			fileData["url"] = shortUrl
 			// Save the file with the "url" property
 			f, _ = json.MarshalIndent(fileData, "", "\t")
-			err = ioutil.WriteFile(savePath, f, 0644)
+			err = os.WriteFile(savePath, f, 0644)
 			if err != nil {
 				return burrito.WrapErrorf(err, fileWriteError, savePath)
 			}
@@ -182,7 +181,7 @@ func getResolversMap() (*map[string]ResolverMapItem, error) {
 	// the combined user config, the final resolver map is created.
 	resolvers := make(map[string]interface{})
 	loadResolversFromPath := func(path string) error {
-		globalResolvers, err := ioutil.ReadDir(path)
+		globalResolvers, err := os.ReadDir(path)
 		if err != nil {
 			return burrito.WrapErrorf(
 				err, "Failed to list files in the directory.\nPath: %s",
@@ -193,7 +192,7 @@ func getResolversMap() (*map[string]ResolverMapItem, error) {
 				continue
 			}
 			filePath := filepath.Join(path, resolver.Name())
-			f, err := ioutil.ReadFile(filePath)
+			f, err := os.ReadFile(filePath)
 			if err != nil {
 				return burrito.WrapErrorf(err, fileReadError, filePath)
 			}

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -4,7 +4,6 @@ package regolith
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -108,7 +107,7 @@ func (u *UserConfig) fillDefaults() {
 // of the config.
 func (u *UserConfig) fillWithFileData(path string) error {
 	if _, err := os.Stat(path); err == nil {
-		file, err := ioutil.ReadFile(path)
+		file, err := os.ReadFile(path)
 		if err != nil {
 			return burrito.WrapErrorf(err, fileReadError, path)
 		}

--- a/regolith/utils_minecraft.go
+++ b/regolith/utils_minecraft.go
@@ -1,7 +1,7 @@
 package regolith
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
@@ -19,7 +19,7 @@ func ListWorlds(mojangDir string) ([]*World, error) {
 	var exists = struct{}{}
 
 	worldsPath := path.Join(mojangDir, "minecraftWorlds")
-	files, err := ioutil.ReadDir(worldsPath)
+	files, err := os.ReadDir(worldsPath)
 	if err != nil {
 		return nil, burrito.WrapErrorf(
 			err, "Failed to list files in the directory.\nPath: %s", worldsPath)
@@ -27,7 +27,7 @@ func ListWorlds(mojangDir string) ([]*World, error) {
 	for _, f := range files {
 		if f.IsDir() {
 			worldPath := path.Join(worldsPath, f.Name())
-			worldname, err := ioutil.ReadFile(
+			worldname, err := os.ReadFile(
 				path.Join(worldPath, "levelname.txt"))
 			if err != nil {
 				Logger.Warnf(

--- a/test/apply_filter_test.go
+++ b/test/apply_filter_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ func TestApplyFilter(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}

--- a/test/common.go
+++ b/test/common.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -104,7 +104,7 @@ func listPaths(path string, root string) (map[string]string, error) {
 			if data.IsDir() {
 				result[relPath] = ""
 			} else {
-				content, err := ioutil.ReadFile(path)
+				content, err := os.ReadFile(path)
 				if err != nil {
 					return err
 				}

--- a/test/conditional_filters_test.go
+++ b/test/conditional_filters_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +18,7 @@ func TestConditionalFilter(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}

--- a/test/file_protection_test.go
+++ b/test/file_protection_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +23,7 @@ func TestSwitchingExportTargets(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}
@@ -80,7 +79,7 @@ func TestTriggerFileProtection(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,7 +25,7 @@ func TestRegolithInit(t *testing.T) {
 		t.Fatal("Unable to get list of created paths:", err)
 	}
 	// Create temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}
@@ -62,7 +61,7 @@ func TestRegolithRunMissingRp(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}
@@ -102,7 +101,7 @@ func TestLocalRequirementsInstallAndRun(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}
@@ -142,7 +141,7 @@ func TestExeFilterRun(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}
@@ -203,7 +202,7 @@ func TestProfileFilterRun(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ func TestInstallAllAndRun(t *testing.T) {
 		t.Fatal("Unable load the expected paths:", err)
 	}
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}
@@ -90,7 +89,7 @@ func TestDataModifyRemoteFilter(t *testing.T) {
 		t.Fatal("Unable load the expected paths:", err)
 	}
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "regolith-test")
+	tmpDir, err := os.MkdirTemp("", "regolith-test")
 	if err != nil {
 		t.Fatal("Unable to create temporary directory:", err)
 	}
@@ -141,7 +140,7 @@ func TestInstall(t *testing.T) {
 	// SETUP
 	wd, err1 := os.Getwd()
 	defer os.Chdir(wd) // Go back before the test ends
-	tmpDir, err2 := ioutil.TempDir("", "regolith-test")
+	tmpDir, err2 := os.MkdirTemp("", "regolith-test")
 	defer os.RemoveAll(tmpDir)
 	defer os.Chdir(wd) // 'tmpDir' can't be used when we delete it
 	err3 := copy.Copy( // Copy the test files
@@ -202,7 +201,7 @@ func TestInstallAll(t *testing.T) {
 	// SETUP
 	wd, err1 := os.Getwd()
 	defer os.Chdir(wd) // Go back before the test ends
-	tmpDir, err2 := ioutil.TempDir("", "regolith-test")
+	tmpDir, err2 := os.MkdirTemp("", "regolith-test")
 	defer os.RemoveAll(tmpDir)
 	defer os.Chdir(wd) // 'tmpDir' can't be used when we delete it
 	err3 := copy.Copy( // Copy the test files


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir