### PR TITLE
Fixed move function not being able to recover from failing to move files.

### DIFF
--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -689,7 +689,7 @@ func move(source, destination string) error {
 		}
 		// Move all files in source to destination
 		files, err := ioutil.ReadDir(source)
-		movedFiles := make([][2]string, 100)
+		movedFiles := make([][2]string, 0, 100)
 		movingFailed := false
 		var errMoving error
 		for _, file := range files {
@@ -699,14 +699,14 @@ func move(source, destination string) error {
 			if errMoving != nil {
 				errMoving = burrito.WrapErrorf(
 					errMoving, osRenameError, src, dst)
-				Logger.Warn(
+				Logger.Warnf(
 					"Failed to move content of directory.\n"+
 						"\tSource: %s\n"+
 						"\tTarget: %s\n\n"+
 						"\tOperation failed while moving a file:\n"+
 						"\tSource: %s\n"+
-						"\tTarget: %s\n\n",
-					"\tTrying to recover from error...",
+						"\tTarget: %s\n\n"+
+						"\tTrying to recover from error...",
 					source, destination, src, dst)
 				movingFailed = true
 				break
@@ -723,7 +723,7 @@ func move(source, destination string) error {
 					// moving files, that we had access to just a moment ago.
 					Logger.Fatalf(
 						"Regolith failed to recover from error which occured "+
-							"while moving files from directory.\b"+
+							"while moving files from directory.\n"+
 							"\tSource: %s\n"+
 							"\tTarget: %s\n\n"+
 							"\tRecovery failed while moving file.\n"+


### PR DESCRIPTION
The `move()` function from `file_system.go` is a function for moving directories.
It creates a slice that it uses to store the list of the files it moved. If it fails moving the a file it uses that list to move the files that were moved successfully back to their original location, to restore the folder structure.

The slice is created here:
https://github.com/Bedrock-OSS/regolith/blob/770458c6bc75ab14365dab7375c4d81d4a733d02/regolith/file_system.go#L692

The intention was to create a slice with 100 capacity, but 0 length (to avoid constant, unnecessary memory reallocation). The code creates a slice that has capacity and length 100 filled with empty values, which causes issues when move fails before filling the list.

This PR fixes the problem.