### PR TITLE
Changed the order of names that regolith uses to search for python executable

### DIFF
--- a/regolith/compatibility_other_os.go
+++ b/regolith/compatibility_other_os.go
@@ -5,6 +5,12 @@ package regolith
 
 import "github.com/Bedrock-OSS/go-burrito/burrito"
 
+// pythonExeNames is the list of strings with possible names of the Python
+// executable. The order of the names determines the order in which they are
+// tried.
+var pythonExeNames = []string{"python3", "python"}
+
+
 // venvScriptsPath is a folder name between "venv" and "python" that leads to
 // the python executable.
 const venvScriptsPath = "bin"

--- a/regolith/compatibility_windows.go
+++ b/regolith/compatibility_windows.go
@@ -12,6 +12,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// pythonExeNames is the list of strings with possible names of the Python
+// executable. The order of the names determines the order in which they are
+// tried.
+var pythonExeNames = []string{"python", "python3"}
+
 // venvScriptsPath is a folder name between "venv" and "python" that leads to
 // the python executable.
 const venvScriptsPath = "Scripts"

--- a/regolith/filter_python.go
+++ b/regolith/filter_python.go
@@ -239,7 +239,7 @@ func needsVenv(requirementsFilePath string) bool {
 
 func findPython() (string, error) {
 	var err error
-	for _, c := range []string{"python3", "python"} {
+	for _, c := range pythonExeNames {
 		_, err = exec.LookPath(c)
 		if err == nil {
 			return c, nil


### PR DESCRIPTION
- Currently Regolith searches for python3 first and than, python.
- After this change regolith will search for python first and than python3 (on Windows).
- Other platforms remain unchanged.