### PR TITLE
Implement resolver cache

### DIFF
--- a/docs/docs/guide/installing-filters.md
+++ b/docs/docs/guide/installing-filters.md
@@ -101,3 +101,14 @@ regolith install name_ninja --update
 ```
 
 Alternatively, you can modify the `version` field in `config.json` and run `regolith install-all`. Regolith install-all is useful for working in a team, when other team members may have to update or add filters to the project.
+
+### Updating resolvers
+
+When using short names for filters, Regolith uses a resolver file from a remote repository to determine the URL of the filter.
+By default, this remote repository is cached and only updated after 5 minutes since last update. If you want to update the resolver file immediately, you can use the `regolith update-resolver` command.
+
+Alternatively, you can use the `--force-resolver-update` flag to force the resolvers to update when installing a filter.
+
+```
+regolith install name_ninja --force-resolver-update
+```

--- a/docs/docs/guide/user-configuration.md
+++ b/docs/docs/guide/user-configuration.md
@@ -15,6 +15,7 @@ preferences for Regolith.
 Default: `false`
 
 If set to `true`, the Regolith projects will store their cache (filters, their dependencies, etc.) in the app data folder, instead of the `.regolith` folder in the project folder.
+
 ### `username: string`
 
 Default: `"Your name"`
@@ -26,6 +27,12 @@ The username of the user, which will be used in the `author` field of the `manif
 Default: `["github.com/Bedrock-OSS/regolith-filter-resolver/resolver.json"]`
 
 A list of resolvers, which will be used to resolve filter names to URLs for downloding when using the `regolith install` command. The default URL is always added to the end of the list. Note that the "URLs" used by the resolvers are not actual URLs. They have two parts, separated by `/`. The first part is an url to a repository on GitHub, and the second part is a path to the resolver file relative to the root of the repository. For example, the default resolver is on the `github.com/Bedrock-OSS/regolith-filter-resolver` repository, in the `resolver.json` file, but `github.com/Bedrock-OSS/regolith-filter-resolver/resolver.json` is not a valid URL.
+
+### `resolver_cache_update_cooldown: string`
+
+Default: `"5m"`
+
+The cooldown between cache updates for the resolvers. The cooldown is specified in the [Go duration format](https://pkg.go.dev/time#ParseDuration).
 
 ## The `regolith config` command
 

--- a/main.go
+++ b/main.go
@@ -156,6 +156,11 @@ The printing commands can take the --full flag to print configuration with the d
 included (if they're not defined in the config file). Without the flag, the undefined properties
 will be printed as null or empty list.
 `
+const regolithUpdateResolversDesc = `
+Updates every resolver repository in the "resolvers" list in the user configuration. This command
+is especially useful when a adding a new filter to the resolver file and you want to make sure that
+the new filter is available in the Regolith.
+`
 
 func main() {
 	// Schedule error handling
@@ -209,6 +214,7 @@ func main() {
 		},
 	}
 	subcommands = append(subcommands, cmdInit)
+
 	// regolith install
 	var force, update, resolverRefresh bool
 	cmdInstall := &cobra.Command{
@@ -230,6 +236,7 @@ func main() {
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
 	subcommands = append(subcommands, cmdInstall)
+
 	// regolith install-all
 	cmdInstallAll := &cobra.Command{
 		Use:   "install-all",
@@ -242,6 +249,7 @@ func main() {
 	cmdInstallAll.Flags().BoolVarP(
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
 	subcommands = append(subcommands, cmdInstallAll)
+
 	// regolith run
 	cmdRun := &cobra.Command{
 		Use:   "run [profile_name]",
@@ -256,6 +264,7 @@ func main() {
 		},
 	}
 	subcommands = append(subcommands, cmdRun)
+
 	// regolith watch
 	cmdWatch := &cobra.Command{
 		Use:   "watch [profile_name]",
@@ -270,6 +279,7 @@ func main() {
 		},
 	}
 	subcommands = append(subcommands, cmdWatch)
+
 	// regolith apply-filter
 	cmdApplyFilter := &cobra.Command{
 		Use:   "apply-filter <filter_name> [filter_args...]",
@@ -286,16 +296,6 @@ func main() {
 		},
 	}
 	subcommands = append(subcommands, cmdApplyFilter)
-	// regolith clean
-	var userCache bool
-	cmdClean := &cobra.Command{
-		Use:   "clean",
-		Short: "Cleans Regolith cache",
-		Long:  regolithCleanDesc,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err = regolith.Clean(burrito.PrintStackTrace, userCache)
-		},
-	}
 
 	// regolith config
 	cmdConfig := &cobra.Command{
@@ -311,17 +311,38 @@ func main() {
 			err = regolith.ManageConfig(burrito.PrintStackTrace, full, delete, append, index, args)
 		},
 	}
-
 	cmdConfig.Flags().BoolP("full", "f", false, "When printing, prints the full configuration including default values.")
 	cmdConfig.Flags().BoolP("delete", "d", false, "Delete property")
 	cmdConfig.Flags().BoolP("append", "a", false, "Append value to array property")
 	cmdConfig.Flags().IntP("index", "i", -1, "The index of the array property on which to act")
 	subcommands = append(subcommands, cmdConfig)
 
+	// regolith clean
+	var userCache bool
+	cmdClean := &cobra.Command{
+		Use:   "clean",
+		Short: "Cleans Regolith cache",
+		Long:  regolithCleanDesc,
+		Run: func(cmd *cobra.Command, _ []string) {
+			err = regolith.Clean(burrito.PrintStackTrace, userCache)
+		},
+	}
 	cmdClean.Flags().BoolVarP(
 		&userCache, "user-cache", "u", false, "Clears all caches stored in user data, instead of the cache of "+
 			"the current project")
 	subcommands = append(subcommands, cmdClean)
+
+	// regolith update-resolvers
+	cmdUpdateResolvers := &cobra.Command{
+		Use:   "update-resolvers",
+		Short: "Updates cached resolver repositories",
+		Long:  regolithUpdateResolversDesc,
+		Run: func(cmd *cobra.Command, _ []string) {
+			err = regolith.UpdateResolvers(burrito.PrintStackTrace)
+		},
+	}
+	subcommands = append(subcommands, cmdUpdateResolvers)
+
 	// add --debug and --timings flag to every command
 	for _, cmd := range subcommands {
 		cmd.Flags().BoolVarP(&burrito.PrintStackTrace, "debug", "", false, "Enables debugging")

--- a/main.go
+++ b/main.go
@@ -157,8 +157,8 @@ included (if they're not defined in the config file). Without the flag, the unde
 will be printed as null or empty list.
 `
 const regolithUpdateResolversDesc = `
-Updates every resolver repository in the "resolvers" list in the user configuration. This command
-is especially useful when a adding a new filter to the resolver file and you want to make sure that
+Updates every resolver repository in the "resolvers" list in the user configuration. This command 
+is particularly useful if you are adding a new filter to the resolver file and want to ensure that 
 the new filter is available in the Regolith.
 `
 

--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func main() {
 	}
 	subcommands = append(subcommands, cmdInit)
 	// regolith install
-	var force, update bool
+	var force, update, resolverRefresh bool
 	cmdInstall := &cobra.Command{
 		Use:   "install [filters...]",
 		Short: "Downloads and installs filters from the internet and adds them to the filterDefinitions list",
@@ -220,11 +220,13 @@ func main() {
 				cmd.Help()
 				return
 			}
-			err = regolith.Install(filters, force || update, burrito.PrintStackTrace)
+			err = regolith.Install(filters, force || update, resolverRefresh, burrito.PrintStackTrace)
 		},
 	}
 	cmdInstall.Flags().BoolVarP(
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
+	cmdInstall.Flags().BoolVar(
+		&resolverRefresh, "force-resolver-refresh", false, "Force resolvers refresh.")
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
 	subcommands = append(subcommands, cmdInstall)

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -204,4 +204,10 @@ const (
 		"Minecraft directory: %s"
 
 	projectSuspiciousDirError = "Cannot initialize the project in a suspicious location."
+
+	resolverPathCacheError = "Failed to get the cache path of the resolver file.\n" +
+		"Short URL: %s"
+
+	resolverResolveUrlError = "Failed to resolve the URL of the resolver file for the download.\n" +
+		"Short URL: %s"
 )

--- a/regolith/install_add.go
+++ b/regolith/install_add.go
@@ -72,7 +72,7 @@ func installFilters(
 // parseInstallFilterArgs parses a list of arguments of the
 // "regolith install" command and returns a list of download tasks.
 func parseInstallFilterArgs(
-	filters []string,
+	filters []string, refreshResolvers bool,
 ) ([]*parsedInstallFilterArg, error) {
 	var result []*parsedInstallFilterArg
 	if len(filters) == 0 {
@@ -119,7 +119,7 @@ func parseInstallFilterArgs(
 		} else {
 			// Example inputs: "name_ninja==HEAD", "name_ninja"
 			name = url
-			url, err = ResolveUrl(name)
+			url, err = ResolveUrl(name, refreshResolvers)
 			if err != nil {
 				return nil, burrito.WrapErrorf(
 					err,

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -51,7 +51,7 @@ func Install(filters []string, force, debug bool) error {
 			"Failed to get the list of filter definitions from config file.")
 	}
 	// Get dotRegolithPath
-	dotRegolithPath, err := GetDotRegolith(false, ".")
+	dotRegolithPath, err := GetDotRegolith(".")
 	if err != nil {
 		return burrito.WrapError(
 			err, "Unable to get the path to regolith cache folder.")
@@ -150,7 +150,7 @@ func InstallAll(force, debug bool) error {
 		return burrito.WrapError(err, "Failed to load config.json.")
 	}
 	// Get dotRegolithPath
-	dotRegolithPath, err := GetDotRegolith(false, ".")
+	dotRegolithPath, err := GetDotRegolith(".")
 	if err != nil {
 		return burrito.WrapError(
 			err, "Unable to get the path to regolith cache folder.")
@@ -195,7 +195,7 @@ func runOrWatch(profileName string, debug, watch bool) error {
 			"Profile %q does not exist in the configuration.", profileName)
 	}
 	// Get dotRegolithPath
-	dotRegolithPath, err := GetDotRegolith(false, ".")
+	dotRegolithPath, err := GetDotRegolith(".")
 	if err != nil {
 		return burrito.WrapError(
 			err, "Unable to get the path to regolith cache folder.")
@@ -284,7 +284,7 @@ func ApplyFilter(filterName string, filterArgs []string, debug bool) error {
 				"Filter name: %s", filterName)
 	}
 	// Get dotRegolithPath
-	dotRegolithPath, err := GetDotRegolith(false, ".")
+	dotRegolithPath, err := GetDotRegolith(".")
 	if err != nil {
 		return burrito.WrapError(
 			err, "Unable to get the path to regolith cache folder.")
@@ -460,12 +460,11 @@ func CleanCurrentProject() error {
 	}
 	// Clean cache from AppData
 	Logger.Infof("Cleaning the cache in application data folder...")
-	dotRegolithPath, err := getAppDataDotRegolith(true, ".")
+	dotRegolithPath, err := getAppDataDotRegolith(".")
 	if err != nil {
 		return burrito.WrapError(
 			err, "Unable to get the path to regolith cache folder.")
 	}
-	Logger.Infof("Regolith cache folder is: %s", dotRegolithPath)
 	err = clean(dotRegolithPath)
 	if err != nil {
 		return burrito.WrapErrorf(

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -481,7 +481,7 @@ func CleanUserCache() error {
 	if err != nil {
 		return burrito.WrappedError(osUserCacheDirError)
 	}
-	regolithCacheFiles := filepath.Join(userCache, appDataCachePath)
+	regolithCacheFiles := filepath.Join(userCache, appDataProjectCachePath)
 	Logger.Infof("Regolith cache files are located in: %s", regolithCacheFiles)
 	err = os.RemoveAll(regolithCacheFiles)
 	if err != nil {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -507,6 +507,16 @@ func Clean(debug, userCache bool) error {
 	}
 }
 
+// UpdateResolvers handles the "regolith update-resolvers" command. It updates cached resolver repositories.
+//
+// The "debug" parameter is a boolean that determines if the debug messages
+// should be printed.
+func UpdateResolvers(debug bool) error {
+	InitLogging(debug)
+	_, _, err := DownloadResolverMaps(true)
+	return err
+}
+
 // manageUserConfigPrint is a helper function for ManageConfig used to print
 // the specified value from the user configuration.
 func manageUserConfigPrint(debug, full bool, key string) error {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
 )
@@ -589,6 +590,16 @@ func manageUserConfigEdit(debug bool, index int, key, value string) error {
 			return burrito.WrappedError("Cannot use --index with non-array property.")
 		}
 		userConfig.Username = &value
+	case "resolver_cache_update_cooldown":
+		if index != -1 {
+			return burrito.WrappedError("Cannot use --index with non-array property.")
+		}
+		_, err = time.ParseDuration(value)
+		if err != nil {
+			return burrito.WrapErrorf(err, "Invalid value for duration property.\n"+
+				"\tValue: %s", value)
+		}
+		userConfig.ResolverCacheUpdateCooldown = &value
 	case "resolvers":
 		if index == -1 {
 			userConfig.Resolvers = append(userConfig.Resolvers, value)

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -29,7 +29,7 @@ import (
 //
 // The "debug" parameter is a boolean that determines if the debug messages
 // should be printed.
-func Install(filters []string, force, debug bool) error {
+func Install(filters []string, force, refreshResolvers, debug bool) error {
 	InitLogging(debug)
 	Logger.Info("Installing filters...")
 	if !hasGit() {
@@ -63,7 +63,7 @@ func Install(filters []string, force, debug bool) error {
 	}
 	defer func() { sessionLockErr = unlockSession() }()
 	// Parse arguments into download tasks (requires downloading resolvers)
-	parsedArgs, err := parseInstallFilterArgs(filters)
+	parsedArgs, err := parseInstallFilterArgs(filters, refreshResolvers)
 	if err != nil {
 		return burrito.WrapError(err, "Failed to parse arguments.")
 	}

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -89,9 +89,9 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 	case "resolver_cache_update_cooldown":
 		value := "null"
 		if u.Username != nil {
-			value = fmt.Sprintf("%v", *u.Username)
+			value = fmt.Sprintf("%v", *u.ResolverCacheUpdateCooldown)
 		}
-		return fmt.Sprintf("username: %v", value), nil
+		return fmt.Sprintf("resolver_cache_update_cooldown: %v", value), nil
 	}
 	return "", burrito.WrapErrorf(nil, invalidUserConfigPropertyError, name)
 }

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -36,13 +36,17 @@ type UserConfig struct {
 	// Resolvers is a list of URLs to resolvers that Regolith will use to find
 	// filters for the "regolith install" command.
 	Resolvers []string `json:"resolvers,omitempty"`
+
+	// ResolverCacheUpdateCooldown is a cooldown duration, to not update resolver cache too often.
+	ResolverCacheUpdateCooldown *string `json:"resolver_cache_update_cooldown,omitempty"`
 }
 
 func NewUserConfig() *UserConfig {
 	return &UserConfig{
-		UseProjectAppDataStorage: nil,
-		Username:                 nil,
-		Resolvers:                []string{},
+		UseProjectAppDataStorage:    nil,
+		Username:                    nil,
+		Resolvers:                   []string{},
+		ResolverCacheUpdateCooldown: nil,
 	}
 }
 
@@ -51,6 +55,8 @@ func (u *UserConfig) String() string {
 	extra, _ := u.stringPropertyValue("username")
 	result += "\n" + extra
 	extra, _ = u.stringPropertyValue("resolvers")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("resolver_cache_update_cooldown")
 	result += "\n" + extra
 	return result
 }
@@ -80,6 +86,12 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 			result += fmt.Sprintf("\t- [%v] %s\n", i, resolver)
 		}
 		return result, nil
+	case "resolver_cache_update_cooldown":
+		value := "null"
+		if u.Username != nil {
+			value = fmt.Sprintf("%v", *u.Username)
+		}
+		return fmt.Sprintf("username: %v", value), nil
 	}
 	return "", burrito.WrapErrorf(nil, invalidUserConfigPropertyError, name)
 }
@@ -93,6 +105,10 @@ func (u *UserConfig) fillDefaults() {
 	if u.Username == nil {
 		u.Username = new(string)
 		*u.Username = "Your name"
+	}
+	if u.ResolverCacheUpdateCooldown == nil {
+		u.ResolverCacheUpdateCooldown = new(string)
+		*u.ResolverCacheUpdateCooldown = "5m"
 	}
 	// Make sure resolvers is not nil and append the default resolver
 	if u.Resolvers == nil {

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -192,12 +192,11 @@ func getAppDataDotRegolith(projectRoot string) (string, error) {
 		return "", burrito.WrapErrorf(err, filepathAbsError, projectRoot)
 	}
 	path, err := getAppDataCachePath(appDataProjectCachePath, absoluteProjectRoot)
-	if err == nil {
-		Logger.Infof(
-			"Regolith project cache is in:\n\t%s",
-			path)
+	if err != nil {
+		return "", burrito.PassError(err)
 	}
-	return path, burrito.PassError(err)
+	Logger.Infof("Regolith project cache is in:\n\t%s", path)
+	return path, nil
 }
 
 // GetDotRegolith returns the path to the directory where Regolith stores

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -139,7 +139,7 @@ func LogStd(in io.ReadCloser, logFunc func(template string, args ...interface{})
 }
 
 // getAppDataDotRegolith gets the dotRegolithPath from th app data folder
-func getAppDataDotRegolith(silent bool, projectRoot string) (string, error) {
+func getAppDataDotRegolith(projectRoot string) (string, error) {
 	// App data enabled - use user cache dir
 	userCache, err := os.UserCacheDir()
 	if err != nil {
@@ -158,11 +158,9 @@ func getAppDataDotRegolith(silent bool, projectRoot string) (string, error) {
 	// %userprofile%/AppData/Local/regolith/<md5 of project path>
 	dotRegolithPath := filepath.Join(
 		userCache, appDataCachePath, projectPathHash)
-	if !silent {
-		Logger.Infof(
-			"Regolith project cache is in:\n\t%s",
-			dotRegolithPath)
-	}
+	Logger.Infof(
+		"Regolith project cache is in:\n\t%s",
+		dotRegolithPath)
 	return dotRegolithPath, nil
 }
 
@@ -175,7 +173,7 @@ func getAppDataDotRegolith(silent bool, projectRoot string) (string, error) {
 // unless the silent flag is set to true. The projectRoot path can be relative
 // or absolute and is resolved to an
 // absolute path.
-func GetDotRegolith(silent bool, projectRoot string) (string, error) {
+func GetDotRegolith(projectRoot string) (string, error) {
 	// App data disabled - use .regolith
 	userConfig, err := getCombinedUserConfig()
 	if err != nil {
@@ -184,7 +182,7 @@ func GetDotRegolith(silent bool, projectRoot string) (string, error) {
 	if !*userConfig.UseProjectAppDataStorage {
 		return ".regolith", nil
 	}
-	return getAppDataDotRegolith(silent, projectRoot)
+	return getAppDataDotRegolith(projectRoot)
 }
 
 // acquireSessionLock creates a lock file in specified directory and

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -173,7 +173,7 @@ func TestInstall(t *testing.T) {
 		expectedResultPath = filepath.Join(wd, expectedResultPath)
 		// Install the filter with given version
 		err := regolith.Install(
-			[]string{filterName + "==" + version}, true, true)
+			[]string{filterName + "==" + version}, true, false, true)
 		if err != nil {
 			t.Fatal("'regolith install' failed:", err)
 		}


### PR DESCRIPTION
This PR changes how resolver files are fetched and updated.

Now, it will:
1. Clone whole repository with resolver file to app data, if the repository doesn't exist or is broken
2. Pull changes if repository exists and haven't been updated within last 5 minutes
3. Pull changes, if repository exists and flag `--force-resolver-refresh` has been set

Otherwise it will just use the cache without any additional actions.