### PR TITLE
Add --force flag to init subcommand and allow init, when there are no files, that would be overwritten

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,19 +204,22 @@ func main() {
 	}
 	subcommands := make([]*cobra.Command, 0)
 
+	var force bool
 	// regolith init
 	cmdInit := &cobra.Command{
 		Use:   "init",
 		Short: "Initializes a Regolith project in current directory",
 		Long:  regolithInitDesc,
 		Run: func(cmd *cobra.Command, _ []string) {
-			err = regolith.Init(burrito.PrintStackTrace)
+			err = regolith.Init(burrito.PrintStackTrace, force)
 		},
 	}
+	cmdInit.Flags().BoolVarP(
+		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
 	subcommands = append(subcommands, cmdInit)
 
 	// regolith install
-	var force, update, resolverRefresh bool
+	var update, resolverRefresh bool
 	cmdInstall := &cobra.Command{
 		Use:   "install [filters...]",
 		Short: "Downloads and installs filters from the internet and adds them to the filterDefinitions list",

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -498,6 +498,43 @@ func IsDirEmpty(path string) (bool, error) {
 	return false, nil
 }
 
+// GetMatchingDirContents returns a list of files in the directory that match the
+// ones specified in the files parameter. If the path is not a directory or
+// info about the path can't be obtained it returns an empty list and an error.
+func GetMatchingDirContents(path string, files []string) ([]string, error) {
+	result := make([]string, 0)
+	if stat, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return result, burrito.WrappedErrorf(osStatErrorIsNotExist, path)
+		}
+		return result, burrito.WrapErrorf(err, osStatErrorAny, path)
+	} else if !stat.IsDir() {
+		return result, burrito.WrappedErrorf(isDirNotADirError, path)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return result, burrito.WrapErrorf(err, osOpenError, path)
+	}
+	defer f.Close()
+	names, err := f.Readdirnames(0)
+	if err == io.EOF {
+		return result, nil
+	} else if err != nil {
+		return result, burrito.WrapErrorf(
+			err,
+			"Failed to access subdirectories list.\n"+
+				"Path: %s", path)
+	}
+	for _, name := range names {
+		// Need to use lowercase because Windows is case-insensitive
+		if stringInSlice(strings.ToLower(name), files) {
+			result = append(result, name)
+		}
+	}
+	// err is nil -> not empty
+	return result, nil
+}
+
 // AreFilesEqual compares files from two paths A and B and returns true if
 // they're equal.
 func AreFilesEqual(a, b string) (bool, error) {

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -326,3 +326,12 @@ func MeasureEnd() {
 	Logger.Infof("%s took %s (%s)", lastMeasure.Name, duration, lastMeasure.Location)
 	lastMeasure = nil
 }
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -39,7 +39,7 @@ func TestRegolithInit(t *testing.T) {
 		t.Fatal("Unable to change working directory:", err.Error())
 	}
 	// THE TEST
-	err = regolith.Init(true)
+	err = regolith.Init(true, false)
 	if err != nil {
 		t.Fatal("'regolith init' failed:", err.Error())
 	}


### PR DESCRIPTION
Now checks for following files and directories before init:
```
config.json
packs
.regolith
.gitignore
```
If any of these are present, it will result in error
```
[ERROR] Cannot initialize the project, because <path> contains files, that will be overwritten on init.
   >> If you want to proceed, use --force flag
   >> Disallowed files and directories found: .gitignore, .regolith, config.json, packs
```

Additionally ` --force` flag has been added to `init` subcommand, that allows to bypass this check and overwrite files.