### PR TITLE
Add `--profile` flag to `install` subcommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,7 +230,7 @@ func main() {
 				cmd.Help()
 				return
 			}
-			err = regolith.Install(filters, force || update, resolverRefresh, cmd.Flags().Lookup("add").Changed, profiles, burrito.PrintStackTrace)
+			err = regolith.Install(filters, force || update, resolverRefresh, cmd.Flags().Lookup("profile").Changed, profiles, burrito.PrintStackTrace)
 		},
 	}
 	cmdInstall.Flags().BoolVarP(
@@ -239,8 +239,8 @@ func main() {
 		&resolverRefresh, "force-resolver-refresh", false, "Force resolvers refresh.")
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
-	cmdInstall.Flags().StringSliceVarP(&profiles, "add", "a", profiles, "Adds the installed filters to the specified profiles. If no profile is provided, the filter will be added to the default profile.")
-	cmdInstall.Flags().Lookup("add").NoOptDefVal = "default"
+	cmdInstall.Flags().StringSliceVarP(&profiles, "profile", "p", profiles, "Adds installed filters to the specified profiles. If no profile is provided, the filter will be added to the default profile.")
+	cmdInstall.Flags().Lookup("profile").NoOptDefVal = "default"
 	subcommands = append(subcommands, cmdInstall)
 
 	// regolith install-all

--- a/main.go
+++ b/main.go
@@ -218,8 +218,7 @@ func main() {
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
 	subcommands = append(subcommands, cmdInit)
 
-	var add bool
-	profile := "default"
+	profiles := []string{"default"}
 	// regolith install
 	var update, resolverRefresh bool
 	cmdInstall := &cobra.Command{
@@ -231,7 +230,7 @@ func main() {
 				cmd.Help()
 				return
 			}
-			err = regolith.Install(filters, force || update, resolverRefresh, add, profile, burrito.PrintStackTrace)
+			err = regolith.Install(filters, force || update, resolverRefresh, cmd.Flags().Lookup("add").Changed, profiles, burrito.PrintStackTrace)
 		},
 	}
 	cmdInstall.Flags().BoolVarP(
@@ -240,10 +239,8 @@ func main() {
 		&resolverRefresh, "force-resolver-refresh", false, "Force resolvers refresh.")
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
-	cmdInstall.Flags().BoolVarP(
-		&add, "add", "a", false, "Adds the installed filters to the profile specified by the 'profile' flag. If no profile is provided, the filter will be added to the default profile.")
-	cmdInstall.Flags().StringVarP(
-		&profile, "profile", "p", "", "Add installed filters to the specified profile.")
+	cmdInstall.Flags().StringSliceVarP(&profiles, "add", "a", profiles, "Adds the installed filters to the specified profiles. If no profile is provided, the filter will be added to the default profile.")
+	cmdInstall.Flags().Lookup("add").NoOptDefVal = "default"
 	subcommands = append(subcommands, cmdInstall)
 
 	// regolith install-all

--- a/main.go
+++ b/main.go
@@ -218,6 +218,8 @@ func main() {
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
 	subcommands = append(subcommands, cmdInit)
 
+	var add bool
+	profile := "default"
 	// regolith install
 	var update, resolverRefresh bool
 	cmdInstall := &cobra.Command{
@@ -229,7 +231,7 @@ func main() {
 				cmd.Help()
 				return
 			}
-			err = regolith.Install(filters, force || update, resolverRefresh, burrito.PrintStackTrace)
+			err = regolith.Install(filters, force || update, resolverRefresh, add, profile, burrito.PrintStackTrace)
 		},
 	}
 	cmdInstall.Flags().BoolVarP(
@@ -238,6 +240,10 @@ func main() {
 		&resolverRefresh, "force-resolver-refresh", false, "Force resolvers refresh.")
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
+	cmdInstall.Flags().BoolVarP(
+		&add, "add", "a", false, "Adds the installed filters to the profile specified by the 'profile' flag. If no profile is provided, the filter will be added to the default profile.")
+	cmdInstall.Flags().StringVarP(
+		&profile, "profile", "p", "", "Add installed filters to the specified profile.")
 	subcommands = append(subcommands, cmdInstall)
 
 	// regolith install-all

--- a/regolith/config_unparsed.go
+++ b/regolith/config_unparsed.go
@@ -38,7 +38,7 @@ func LoadConfigAsMap() (map[string]interface{}, error) {
 // dataPathFromConfigMap returns the value of the data path from the config
 // file map, without parsing it to a Config object.
 func dataPathFromConfigMap(config map[string]interface{}) (string, error) {
-	return FindStringByJSONPath(config, "regolith/dataPath")
+	return FindByJSONPath[string](config, "regolith/dataPath")
 }
 
 // filterDefinitionFromConfigMap returns the filter definitions as map from
@@ -46,11 +46,11 @@ func dataPathFromConfigMap(config map[string]interface{}) (string, error) {
 func filterDefinitionsFromConfigMap(
 	config map[string]interface{},
 ) (map[string]interface{}, error) {
-	return FindObjectByJSONPath(config, "regolith/filterDefinitions")
+	return FindByJSONPath[map[string]interface{}](config, "regolith/filterDefinitions")
 }
 
 // useAppDataFromConfigMap returns the useAppData value from the config file
 // map, without parsing it to a Config object.
 func useAppDataFromConfigMap(config map[string]interface{}) (bool, error) {
-	return FindBoolByJSONPath(config, "regolith/useAppData")
+	return FindByJSONPath[bool](config, "regolith/useAppData")
 }

--- a/regolith/config_unparsed.go
+++ b/regolith/config_unparsed.go
@@ -38,15 +38,7 @@ func LoadConfigAsMap() (map[string]interface{}, error) {
 // dataPathFromConfigMap returns the value of the data path from the config
 // file map, without parsing it to a Config object.
 func dataPathFromConfigMap(config map[string]interface{}) (string, error) {
-	regolith, ok := config["regolith"].(map[string]interface{})
-	if !ok {
-		return "", burrito.WrappedErrorf(jsonPathMissingError, "regolith")
-	}
-	dataPath, ok := regolith["dataPath"].(string)
-	if !ok {
-		return "", burrito.WrappedErrorf(jsonPathMissingError, "regolith->dataPath")
-	}
-	return dataPath, nil
+	return FindStringByJSONPath(config, "regolith/dataPath")
 }
 
 // filterDefinitionFromConfigMap returns the filter definitions as map from
@@ -54,33 +46,11 @@ func dataPathFromConfigMap(config map[string]interface{}) (string, error) {
 func filterDefinitionsFromConfigMap(
 	config map[string]interface{},
 ) (map[string]interface{}, error) {
-	regolith, ok := config["regolith"].(map[string]interface{})
-	if !ok {
-		return nil, burrito.WrappedErrorf(jsonPathMissingError, "regolith")
-	}
-	filterDefinitions, ok := regolith["filterDefinitions"].(map[string]interface{})
-	if !ok {
-		return nil, burrito.WrappedErrorf(
-			jsonPathMissingError, "regolith->filterDefinitions")
-	}
-	return filterDefinitions, nil
+	return FindObjectByJSONPath(config, "regolith/filterDefinitions")
 }
 
 // useAppDataFromConfigMap returns the useAppData value from the config file
 // map, without parsing it to a Config object.
 func useAppDataFromConfigMap(config map[string]interface{}) (bool, error) {
-	regolith, ok := config["regolith"].(map[string]interface{})
-	if !ok {
-		return false, burrito.WrappedErrorf(jsonPathMissingError, "regolith")
-	}
-	filterDefinitionsInterface, ok := regolith["useAppData"]
-	if !ok { // false by default
-		return false, nil
-	}
-	filterDefinitions, ok := filterDefinitionsInterface.(bool)
-	if !ok {
-		return false, burrito.WrappedErrorf(
-			jsonPathTypeError, "regolith->useAppData", "bool")
-	}
-	return filterDefinitions, nil
+	return FindBoolByJSONPath(config, "regolith/useAppData")
 }

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -54,7 +54,7 @@ func Install(filters []string, force, refreshResolvers, add bool, profiles []str
 		}
 		// Get the profile
 		for _, profile := range profiles {
-			_, err := FindObjectByJSONPath(config, "regolith/profiles/"+profile)
+			_, err := FindByJSONPath[map[string]interface{}](config, "regolith/profiles/"+profile)
 			if err != nil {
 				return burrito.WrapErrorf(
 					err, "Profile %s does not exist or is invalid.", profile)
@@ -138,7 +138,7 @@ func Install(filters []string, force, refreshResolvers, add bool, profiles []str
 		if add {
 			// Add the filter to the profile
 			for _, profile := range profiles {
-				profileMap, err := FindObjectByJSONPath(config, "regolith/profiles/"+profile)
+				profileMap, err := FindByJSONPath[map[string]interface{}](config, "regolith/profiles/"+profile)
 				// This check here is not necessary, because we have identical one at the beginning, but better to be safe
 				if err != nil {
 					return burrito.WrapErrorf(
@@ -725,16 +725,16 @@ func manageUserConfigDelete(debug bool, index int, key string) error {
 
 // ManageConfig handles the "regolith config" command. It can modify or
 // print the user configuration
-// - debug - print debug messages
-// - global - modify global configuration
-// - local - modify local configuration
-// - delete - delete the specified value
-// - append - append a value to an array property of the configuration. Applies
-//   only to the array properties
-// - index - the index of the value to modify. Applies only to the array
-//   properties
-// - args - the arguments of the command, the length of the list must be 0, 1
-//   or 2. The length determines the action of the command.
+//   - debug - print debug messages
+//   - global - modify global configuration
+//   - local - modify local configuration
+//   - delete - delete the specified value
+//   - append - append a value to an array property of the configuration. Applies
+//     only to the array properties
+//   - index - the index of the value to modify. Applies only to the array
+//     properties
+//   - args - the arguments of the command, the length of the list must be 0, 1
+//     or 2. The length determines the action of the command.
 func ManageConfig(debug, full, delete, append bool, index int, args []string) error {
 	InitLogging(debug)
 

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -54,7 +54,7 @@ func Install(filters []string, force, refreshResolvers, add bool, profiles []str
 		}
 		// Get the profile
 		for _, profile := range profiles {
-			_, err := FindByJSONPath[map[string]interface{}](config, "regolith/profiles/"+profile)
+			_, err := FindByJSONPath[map[string]interface{}](config, "regolith/profiles/"+EscapePathPart(profile))
 			if err != nil {
 				return burrito.WrapErrorf(
 					err, "Profile %s does not exist or is invalid.", profile)
@@ -138,7 +138,7 @@ func Install(filters []string, force, refreshResolvers, add bool, profiles []str
 		if add {
 			// Add the filter to the profile
 			for _, profile := range profiles {
-				profileMap, err := FindByJSONPath[map[string]interface{}](config, "regolith/profiles/"+profile)
+				profileMap, err := FindByJSONPath[map[string]interface{}](config, "regolith/profiles/"+EscapePathPart(profile))
 				// This check here is not necessary, because we have identical one at the beginning, but better to be safe
 				if err != nil {
 					return burrito.WrapErrorf(

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -344,7 +344,10 @@ func FindByJSONPath[T any](obj interface{}, path string) (T, error) {
 		return empty, burrito.WrappedErrorf("Object is empty")
 	}
 	// Split the path into parts
-	parts := strings.Split(path, "/")
+	parts, err := splitEscapedString(path)
+	if err != nil {
+		return empty, burrito.WrapErrorf(err, "Invalid path %s", path)
+	}
 	// Find the value
 	value := obj
 	currentPath := ""
@@ -380,4 +383,50 @@ func FindByJSONPath[T any](obj interface{}, path string) (T, error) {
 		return s, nil
 	}
 	return empty, burrito.WrappedErrorf(jsonPathTypeError, path, reflect.TypeOf(empty).String())
+}
+
+func splitEscapedString(s string) ([]string, error) {
+	parts := make([]string, 0)
+	var sb strings.Builder
+	escape := false
+	for _, c := range s {
+		if escape {
+			if c != '\\' && c != '/' {
+				return nil, burrito.WrappedErrorf("Invalid escape sequence \\%c", c)
+			}
+			sb.WriteRune(c)
+			escape = false
+			continue
+		}
+		if c == '\\' {
+			escape = true
+			continue
+		}
+		if c == '/' {
+			if sb.String() != "" {
+				parts = append(parts, sb.String())
+			}
+			sb.Reset()
+			continue
+		}
+		sb.WriteRune(c)
+	}
+	if escape {
+		return nil, burrito.WrappedErrorf("Invalid escape sequence \\")
+	}
+	if sb.String() != "" {
+		parts = append(parts, sb.String())
+	}
+	return parts, nil
+}
+
+func EscapePathPart(s string) string {
+	var sb strings.Builder
+	for _, c := range s {
+		if c == '\\' || c == '/' {
+			sb.WriteRune('\\')
+		}
+		sb.WriteRune(c)
+	}
+	return sb.String()
 }

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -381,19 +381,3 @@ func FindByJSONPath[T any](obj interface{}, path string) (T, error) {
 	}
 	return empty, burrito.WrappedErrorf(jsonPathTypeError, path, reflect.TypeOf(empty).String())
 }
-
-func FindStringByJSONPath(obj interface{}, path string) (string, error) {
-	return FindByJSONPath[string](obj, path)
-}
-
-func FindObjectByJSONPath(obj interface{}, path string) (map[string]interface{}, error) {
-	return FindByJSONPath[map[string]interface{}](obj, path)
-}
-
-func FindArrayByJSONPath(obj interface{}, path string) ([]interface{}, error) {
-	return FindByJSONPath[[]interface{}](obj, path)
-}
-
-func FindBoolByJSONPath(obj interface{}, path string) (bool, error) {
-	return FindByJSONPath[bool](obj, path)
-}

--- a/test/json_path_test.go
+++ b/test/json_path_test.go
@@ -1,0 +1,94 @@
+package test
+
+import (
+	"github.com/Bedrock-OSS/go-burrito/burrito"
+	"github.com/Bedrock-OSS/regolith/regolith"
+	"testing"
+)
+
+func TestSimplePath(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": "bar",
+	}
+	expected := "bar"
+	actual, err := regolith.FindByJSONPath(obj, "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestSimplePath2(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": []interface{}{"bar"},
+	}
+	expected := "bar"
+	actual, err := regolith.FindByJSONPath(obj, "foo/0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestSimplePath3(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+	expected := "baz"
+	actual, err := regolith.FindByJSONPath(obj, "foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestInvalidPath(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+	expected := "Invalid data type.\nJSON Path: foo->bar->baz\nExpected type: object or array"
+	_, err := regolith.FindByJSONPath(obj, "foo/bar/baz")
+	if err == nil {
+		t.Fatal("Expected an error, got nil")
+	}
+	if burrito.GetAllMessages(err)[0] != expected {
+		t.Fatalf("Expected error %v, got %v", expected, burrito.GetAllMessages(err)[0])
+	}
+}
+
+func TestInvalidPath2(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+	expected := "Required JSON path is missing.\nJSON Path: foo->0"
+	_, err := regolith.FindByJSONPath(obj, "foo/0/baz")
+	if err == nil {
+		t.Fatal("Expected an error, got nil")
+	}
+	if burrito.GetAllMessages(err)[0] != expected {
+		t.Fatalf("Expected error %v, got %v", expected, burrito.GetAllMessages(err)[0])
+	}
+}
+
+func TestNullObject(t *testing.T) {
+	expected := "Object is empty"
+	_, err := regolith.FindByJSONPath(nil, "foo/bar/baz")
+	if err == nil {
+		t.Fatal("Expected an error, got nil")
+	}
+	if burrito.GetAllMessages(err)[0] != expected {
+		t.Fatalf("Expected error %v, got %v", expected, burrito.GetAllMessages(err)[0])
+	}
+}

--- a/test/json_path_test.go
+++ b/test/json_path_test.go
@@ -11,7 +11,7 @@ func TestSimplePath(t *testing.T) {
 		"foo": "bar",
 	}
 	expected := "bar"
-	actual, err := regolith.FindByJSONPath(obj, "foo")
+	actual, err := regolith.FindByJSONPath[string](obj, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func TestSimplePath2(t *testing.T) {
 		"foo": []interface{}{"bar"},
 	}
 	expected := "bar"
-	actual, err := regolith.FindByJSONPath(obj, "foo/0")
+	actual, err := regolith.FindByJSONPath[string](obj, "foo/0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func TestSimplePath3(t *testing.T) {
 		},
 	}
 	expected := "baz"
-	actual, err := regolith.FindByJSONPath(obj, "foo/bar")
+	actual, err := regolith.FindByJSONPath[string](obj, "foo/bar")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestInvalidPath(t *testing.T) {
 		},
 	}
 	expected := "Invalid data type.\nJSON Path: foo->bar->baz\nExpected type: object or array"
-	_, err := regolith.FindByJSONPath(obj, "foo/bar/baz")
+	_, err := regolith.FindByJSONPath[string](obj, "foo/bar/baz")
 	if err == nil {
 		t.Fatal("Expected an error, got nil")
 	}
@@ -73,7 +73,7 @@ func TestInvalidPath2(t *testing.T) {
 		},
 	}
 	expected := "Required JSON path is missing.\nJSON Path: foo->0"
-	_, err := regolith.FindByJSONPath(obj, "foo/0/baz")
+	_, err := regolith.FindByJSONPath[string](obj, "foo/0/baz")
 	if err == nil {
 		t.Fatal("Expected an error, got nil")
 	}
@@ -84,7 +84,7 @@ func TestInvalidPath2(t *testing.T) {
 
 func TestNullObject(t *testing.T) {
 	expected := "Object is empty"
-	_, err := regolith.FindByJSONPath(nil, "foo/bar/baz")
+	_, err := regolith.FindByJSONPath[string](nil, "foo/bar/baz")
 	if err == nil {
 		t.Fatal("Expected an error, got nil")
 	}

--- a/test/json_path_test.go
+++ b/test/json_path_test.go
@@ -50,6 +50,34 @@ func TestSimplePath3(t *testing.T) {
 	}
 }
 
+func TestEscapedPath(t *testing.T) {
+	obj := map[string]interface{}{
+		"fo/o": "bar",
+	}
+	expected := "bar"
+	actual, err := regolith.FindByJSONPath[string](obj, "fo\\/o")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestEscapedPath2(t *testing.T) {
+	obj := map[string]interface{}{
+		"fo/o": "bar",
+	}
+	expected := "bar"
+	actual, err := regolith.FindByJSONPath[string](obj, regolith.EscapePathPart("fo/o"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
 func TestInvalidPath(t *testing.T) {
 	obj := map[string]interface{}{
 		"foo": map[string]interface{}{

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -173,7 +173,7 @@ func TestInstall(t *testing.T) {
 		expectedResultPath = filepath.Join(wd, expectedResultPath)
 		// Install the filter with given version
 		err := regolith.Install(
-			[]string{filterName + "==" + version}, true, false, false, "default", true)
+			[]string{filterName + "==" + version}, true, false, false, []string{"default"}, true)
 		if err != nil {
 			t.Fatal("'regolith install' failed:", err)
 		}

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -173,7 +173,7 @@ func TestInstall(t *testing.T) {
 		expectedResultPath = filepath.Join(wd, expectedResultPath)
 		// Install the filter with given version
 		err := regolith.Install(
-			[]string{filterName + "==" + version}, true, false, true)
+			[]string{filterName + "==" + version}, true, false, false, "default", true)
 		if err != nil {
 			t.Fatal("'regolith install' failed:", err)
 		}


### PR DESCRIPTION
This is a simple change, that adds 1 flag:
1. `--profile` (or `-p`) - Adds installed filters to the specified profiles. If no profile is provided, the filters will be added to the default profile

Examples:
```sh
# Just install filter
regolith install <filter>
# Install and add to default profile
regolith install --profile <filter>
# Install and add to test profile
regolith install --profile=test <filter>
# Install and add to test and default profiles
regolith install --profile=test,default <filter>
```

Additionally I implemented finding values in JSON by simple path. It's not actually JSONPath, but more like a file path. It's a utility function to get around long blocks of getting value, checking if it exists and checking the type.