### PR TITLE
Implement global cache for filters

### DIFF
--- a/docs/docs/guide/installing-filters.md
+++ b/docs/docs/guide/installing-filters.md
@@ -112,3 +112,14 @@ Alternatively, you can use the `--force-resolver-update` flag to force the resol
 ```
 regolith install name_ninja --force-resolver-update
 ```
+
+### Updating filter cache
+
+Regolith caches the filter repository when you install online filters. By default, the repository cache is updated every 5 minutes. 
+However, if you need to update the cache immediately, you can use the `--force-filter-update` flag while installing a filter.
+
+```bash
+regolith install name_ninja --force-filter-update
+# OR
+regolith install-all --force-filter-update
+```

--- a/docs/docs/guide/installing-filters.md
+++ b/docs/docs/guide/installing-filters.md
@@ -115,7 +115,7 @@ regolith install name_ninja --force-resolver-update
 
 ### Updating filter cache
 
-Regolith caches the filter repository when you install online filters. By default, the repository cache is updated every 5 minutes. 
+Regolith caches the filter repository when you install online filters. To avoid unnecessary frequent updates, Regolith skips them for installations that occur less than 5 minutes after the last update.
 However, if you need to update the cache immediately, you can use the `--force-filter-update` flag while installing a filter.
 
 ```bash

--- a/docs/docs/guide/user-configuration.md
+++ b/docs/docs/guide/user-configuration.md
@@ -34,6 +34,12 @@ Default: `"5m"`
 
 The cooldown between cache updates for the resolvers. The cooldown is specified in the [Go duration format](https://pkg.go.dev/time#ParseDuration).
 
+### `filter_cache_update_cooldown: string`
+
+Default: `"5m"`
+
+The cooldown between cache updates for the filters. The cooldown is specified in the [Go duration format](https://pkg.go.dev/time#ParseDuration).
+
 ## The `regolith config` command
 
 The `regolith config` command is used to manage the user configuration of Regolith. It can access and modify

--- a/main.go
+++ b/main.go
@@ -220,7 +220,7 @@ func main() {
 
 	profiles := []string{"default"}
 	// regolith install
-	var update, resolverRefresh bool
+	var update, resolverRefresh, filterRefresh bool
 	cmdInstall := &cobra.Command{
 		Use:   "install [filters...]",
 		Short: "Downloads and installs filters from the internet and adds them to the filterDefinitions list",
@@ -230,13 +230,15 @@ func main() {
 				cmd.Help()
 				return
 			}
-			err = regolith.Install(filters, force || update, resolverRefresh, cmd.Flags().Lookup("profile").Changed, profiles, burrito.PrintStackTrace)
+			err = regolith.Install(filters, force || update, resolverRefresh, filterRefresh, cmd.Flags().Lookup("profile").Changed, profiles, burrito.PrintStackTrace)
 		},
 	}
 	cmdInstall.Flags().BoolVarP(
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
 	cmdInstall.Flags().BoolVar(
 		&resolverRefresh, "force-resolver-refresh", false, "Force resolvers refresh.")
+	cmdInstall.Flags().BoolVar(
+		&filterRefresh, "force-filter-refresh", false, "Force filter cache refresh.")
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
 	cmdInstall.Flags().StringSliceVarP(&profiles, "profile", "p", profiles, "Adds installed filters to the specified profiles. If no profile is provided, the filter will be added to the default profile.")
@@ -249,11 +251,13 @@ func main() {
 		Short: "Installs all nonexistent or outdated filters defined in filterDefinitions list",
 		Long:  regolithInstallAllDesc,
 		Run: func(cmd *cobra.Command, _ []string) {
-			err = regolith.InstallAll(force, burrito.PrintStackTrace)
+			err = regolith.InstallAll(force, burrito.PrintStackTrace, filterRefresh)
 		},
 	}
 	cmdInstallAll.Flags().BoolVarP(
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
+	cmdInstallAll.Flags().BoolVar(
+		&filterRefresh, "force-filter-refresh", false, "Force filter cache refresh.")
 	subcommands = append(subcommands, cmdInstallAll)
 
 	// regolith run

--- a/main.go
+++ b/main.go
@@ -328,17 +328,20 @@ func main() {
 	subcommands = append(subcommands, cmdConfig)
 
 	// regolith clean
-	var userCache bool
+	var userCache, filterCache bool
 	cmdClean := &cobra.Command{
 		Use:   "clean",
 		Short: "Cleans Regolith cache",
 		Long:  regolithCleanDesc,
 		Run: func(cmd *cobra.Command, _ []string) {
-			err = regolith.Clean(burrito.PrintStackTrace, userCache)
+			err = regolith.Clean(burrito.PrintStackTrace, userCache, filterCache)
 		},
 	}
 	cmdClean.Flags().BoolVarP(
 		&userCache, "user-cache", "u", false, "Clears all caches stored in user data, instead of the cache of "+
+			"the current project")
+	cmdClean.Flags().BoolVar(
+		&filterCache, "filter-cache", false, "Clears filter cache stored in user data, instead of the cache of "+
 			"the current project")
 	subcommands = append(subcommands, cmdClean)
 

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -33,6 +33,9 @@ const (
 	// Error message displayed when os.Getwd fails
 	osGetwdError = "Failed to get current working directory."
 
+	// Error message displayed when os.Getwd fails
+	osChtimesError = "Failed to update file modification time.\nPath: %s"
+
 	// Common Error message to be reused on top of IsDirEmpty
 	isDirEmptyError = "Failed to check if path is an empty directory.\nPath: %s"
 

--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -416,11 +416,6 @@ func (f *RemoteFilterDefinition) Download(
 }
 
 func downloadFilterRepository(downloadPath, url, ref, filter string, forceUpdate bool) error {
-	globalUserConfig, err := getGlobalUserConfig()
-	globalUserConfig.fillDefaults() // The file must have the default resolver URL
-	if err != nil {
-		return burrito.WrapError(err, getUserConfigError)
-	}
 	config, err := getCombinedUserConfig()
 	if err != nil {
 		return burrito.WrapErrorf(err, getUserConfigError)

--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -453,7 +453,7 @@ clone:
 	if forceUpdate || info.ModTime().Before(time.Now().Add(cooldown*-1)) {
 		// Fetch the repository
 		MeasureStart("Fetch repository %s", url)
-		output, err := RunGitProcess([]string{"fetch"}, cache)
+		output, err := RunGitProcess([]string{"fetch", "--tags"}, cache)
 		if err != nil {
 			Logger.Error(strings.Join(output, "\n"))
 			Logger.Errorf("Failed to fetch repository.\nURL: %s", url)

--- a/regolith/install_add.go
+++ b/regolith/install_add.go
@@ -28,7 +28,7 @@ type parsedInstallFilterArg struct {
 // it returns an error unless the force flag is set.
 func installFilters(
 	filterDefinitions map[string]FilterInstaller, force bool,
-	dataPath, dotRegolithPath string, isInstall bool,
+	dataPath, dotRegolithPath string, isInstall, refreshFilters bool,
 ) error {
 	joinedPath := filepath.Join(dotRegolithPath, "cache/filters")
 	err := CreateDirectoryIfNotExists(joinedPath)
@@ -46,7 +46,7 @@ func installFilters(
 		Logger.Infof("Downloading %q filter...", name)
 		if remoteFilter, ok := filterDefinition.(*RemoteFilterDefinition); ok {
 			// Download the remote filter, and its dependencies
-			err := remoteFilter.Update(force, dotRegolithPath, isInstall)
+			err := remoteFilter.Update(force, dotRegolithPath, isInstall, refreshFilters)
 			if err != nil {
 				return burrito.WrapErrorf(err, remoteFilterDownloadError, name)
 			}

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -37,7 +37,7 @@ var disallowedFiles = []string{
 //
 // The "debug" parameter is a boolean that determines if the debug messages
 // should be printed.
-func Install(filters []string, force, refreshResolvers, add bool, profiles []string, debug bool) error {
+func Install(filters []string, force, refreshResolvers, refreshFilters, add bool, profiles []string, debug bool) error {
 	InitLogging(debug)
 	Logger.Info("Installing filters...")
 	if !hasGit() {
@@ -127,7 +127,7 @@ func Install(filters []string, force, refreshResolvers, add bool, profiles []str
 	}
 	// Download the filter definitions
 	err = installFilters(
-		filterInstallers, force, dataPath, dotRegolithPath, true)
+		filterInstallers, force, dataPath, dotRegolithPath, true, refreshFilters)
 	if err != nil {
 		return burrito.WrapError(err, "Failed to install filters.")
 	}
@@ -179,7 +179,7 @@ func Install(filters []string, force, refreshResolvers, add bool, profiles []str
 //
 // The "debug" parameter is a boolean that determines if the debug messages
 // should be printed.
-func InstallAll(force, debug bool) error {
+func InstallAll(force, debug, refreshFilters bool) error {
 	InitLogging(debug)
 	Logger.Info("Installing filters...")
 	if !hasGit() {
@@ -204,7 +204,7 @@ func InstallAll(force, debug bool) error {
 	defer func() { sessionLockErr = unlockSession() }()
 	// Install the filters
 	err = installFilters(
-		config.FilterDefinitions, force, config.DataPath, dotRegolithPath, false)
+		config.FilterDefinitions, force, config.DataPath, dotRegolithPath, false, refreshFilters)
 	if err != nil {
 		return burrito.WrapError(err, "Could not install filters.")
 	}
@@ -650,6 +650,16 @@ func manageUserConfigEdit(debug bool, index int, key, value string) error {
 				"\tValue: %s", value)
 		}
 		userConfig.ResolverCacheUpdateCooldown = &value
+	case "filter_cache_update_cooldown":
+		if index != -1 {
+			return burrito.WrappedError("Cannot use --index with non-array property.")
+		}
+		_, err = time.ParseDuration(value)
+		if err != nil {
+			return burrito.WrapErrorf(err, "Invalid value for duration property.\n"+
+				"\tValue: %s", value)
+		}
+		userConfig.FilterCacheUpdateCooldown = &value
 	case "resolvers":
 		if index == -1 {
 			userConfig.Resolvers = append(userConfig.Resolvers, value)

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -533,15 +533,35 @@ func CleanUserCache() error {
 	return nil
 }
 
+func CleanFilterCache() error {
+	Logger.Infof("Cleaning Regolith filter cache files from user app data...")
+	// App data enabled - use user cache dir
+	userCache, err := os.UserCacheDir()
+	if err != nil {
+		return burrito.WrappedError(osUserCacheDirError)
+	}
+	regolithCacheFiles := filepath.Join(userCache, appDataFilterCachePath)
+	Logger.Infof("Regolith cache files are located in: %s", regolithCacheFiles)
+	err = os.RemoveAll(regolithCacheFiles)
+	if err != nil {
+		return burrito.WrapErrorf(err, "failed to remove %q folder", regolithCacheFiles)
+	}
+	os.MkdirAll(regolithCacheFiles, 0755)
+	Logger.Infof("Regolith filter files cached in user app data cleaned.")
+	return nil
+}
+
 // Clean handles the "regolith clean" command. It cleans the cache from the
 // dotRegolithPath directory.
 //
 // The "debug" parameter is a boolean that determines if the debug messages
 // should be printed.
-func Clean(debug, userCache bool) error {
+func Clean(debug, userCache, filterCache bool) error {
 	InitLogging(debug)
 	if userCache {
 		return CleanUserCache()
+	} else if filterCache {
+		return CleanFilterCache()
 	} else {
 		return CleanCurrentProject()
 	}

--- a/regolith/resolver.go
+++ b/regolith/resolver.go
@@ -108,7 +108,7 @@ func DownloadResolverMaps(forceUpdate bool) ([]string, []string, error) {
 				MeasureEnd()
 				err = os.Chtimes(cachePath, time.Now(), time.Now())
 				if err != nil {
-					Logger.Debugf("Failed to update cache file modification time.\nPath: %s", cachePath)
+					Logger.Debugf(osChtimesError, cachePath)
 				}
 				// If pull failed, delete the repo and clone it again
 				if err != nil {

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -39,6 +39,9 @@ type UserConfig struct {
 
 	// ResolverCacheUpdateCooldown is a cooldown duration, to not update resolver cache too often.
 	ResolverCacheUpdateCooldown *string `json:"resolver_cache_update_cooldown,omitempty"`
+
+	// FilterCacheUpdateCooldown is a cooldown duration, to not update resolver cache too often.
+	FilterCacheUpdateCooldown *string `json:"filter_cache_update_cooldown,omitempty"`
 }
 
 func NewUserConfig() *UserConfig {
@@ -47,6 +50,7 @@ func NewUserConfig() *UserConfig {
 		Username:                    nil,
 		Resolvers:                   []string{},
 		ResolverCacheUpdateCooldown: nil,
+		FilterCacheUpdateCooldown:   nil,
 	}
 }
 
@@ -57,6 +61,8 @@ func (u *UserConfig) String() string {
 	extra, _ = u.stringPropertyValue("resolvers")
 	result += "\n" + extra
 	extra, _ = u.stringPropertyValue("resolver_cache_update_cooldown")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("filter_cache_update_cooldown")
 	result += "\n" + extra
 	return result
 }
@@ -88,10 +94,16 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 		return result, nil
 	case "resolver_cache_update_cooldown":
 		value := "null"
-		if u.Username != nil {
+		if u.ResolverCacheUpdateCooldown != nil {
 			value = fmt.Sprintf("%v", *u.ResolverCacheUpdateCooldown)
 		}
 		return fmt.Sprintf("resolver_cache_update_cooldown: %v", value), nil
+	case "filter_cache_update_cooldown":
+		value := "null"
+		if u.FilterCacheUpdateCooldown != nil {
+			value = fmt.Sprintf("%v", *u.FilterCacheUpdateCooldown)
+		}
+		return fmt.Sprintf("filter_cache_update_cooldown: %v", value), nil
 	}
 	return "", burrito.WrapErrorf(nil, invalidUserConfigPropertyError, name)
 }
@@ -109,6 +121,10 @@ func (u *UserConfig) fillDefaults() {
 	if u.ResolverCacheUpdateCooldown == nil {
 		u.ResolverCacheUpdateCooldown = new(string)
 		*u.ResolverCacheUpdateCooldown = "5m"
+	}
+	if u.FilterCacheUpdateCooldown == nil {
+		u.FilterCacheUpdateCooldown = new(string)
+		*u.FilterCacheUpdateCooldown = "5m"
 	}
 	// Make sure resolvers is not nil and append the default resolver
 	if u.Resolvers == nil {

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -166,14 +166,18 @@ func LogStd(in io.ReadCloser, logFunc func(template string, args ...interface{})
 	}
 }
 
-// getResolverCache gets the dotRegolithPath from th app data folder
+// getResolverCache gets the appDataResolverCachePath from the app data folder
 func getResolverCache(resolver string) (string, error) {
 	return getAppDataCachePath(appDataResolverCachePath, resolver)
 }
 
-// getResolverCache gets the dotRegolithPath from th app data folder
+// getFilterCache gets the appDataFilterCachePath from the app data folder
 func getFilterCache(url string) (string, error) {
-	return getAppDataCachePath(appDataFilterCachePath, url)
+	path, err := getAppDataCachePath(appDataFilterCachePath, url)
+	if err == nil {
+		Logger.Debugf("Regolith filter cache for %s is in:\n\t%s", url, path)
+	}
+	return path, err
 }
 
 // getAppDataCachePath gets the dotRegolithPath from th app data folder
@@ -194,7 +198,7 @@ func getAppDataCachePath(basePath, cacheId string) (string, error) {
 	return cachePath, nil
 }
 
-// getAppDataDotRegolith gets the dotRegolithPath from th app data folder
+// getAppDataDotRegolith gets the dotRegolithPath from the app data folder
 func getAppDataDotRegolith(projectRoot string) (string, error) {
 	// Make sure that projectsRoot is an absolute path
 	absoluteProjectRoot, err := filepath.Abs(projectRoot)

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -27,6 +27,10 @@ const appDataProjectCachePath = "regolith/project-cache"
 // app data
 const appDataResolverCachePath = "regolith/resolver-cache"
 
+// appDataResolverCachePath is a path to the resolver cache directory relative to the user's
+// app data
+const appDataFilterCachePath = "regolith/filter-cache"
+
 var Version = "unversioned"
 
 // nth returns the ordinal numeral of the index of a table. For example:
@@ -165,6 +169,11 @@ func LogStd(in io.ReadCloser, logFunc func(template string, args ...interface{})
 // getResolverCache gets the dotRegolithPath from th app data folder
 func getResolverCache(resolver string) (string, error) {
 	return getAppDataCachePath(appDataResolverCachePath, resolver)
+}
+
+// getResolverCache gets the dotRegolithPath from th app data folder
+func getFilterCache(url string) (string, error) {
+	return getAppDataCachePath(appDataFilterCachePath, url)
 }
 
 // getAppDataCachePath gets the dotRegolithPath from th app data folder

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -124,7 +124,7 @@ func TestLocalRequirementsInstallAndRun(t *testing.T) {
 	// Switch to the working directory
 	os.Chdir(filepath.Join(tmpDir, "project"))
 	// THE TEST
-	err = regolith.InstallAll(false, true)
+	err = regolith.InstallAll(false, true, false)
 	if err != nil {
 		t.Fatal("'regolith install-all' failed", err.Error())
 	}

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -54,7 +54,7 @@ func TestInstallAllAndRun(t *testing.T) {
 	os.Chdir(workingDir)
 	// THE TEST
 	// Run InstallDependencies
-	err = regolith.InstallAll(false, true)
+	err = regolith.InstallAll(false, true, false)
 	if err != nil {
 		t.Fatal("'regolith install-all' failed:", err)
 	}
@@ -116,7 +116,7 @@ func TestDataModifyRemoteFilter(t *testing.T) {
 	os.Chdir(workingDir)
 	// THE TEST
 	// Run InstallDependencies
-	err = regolith.InstallAll(false, true)
+	err = regolith.InstallAll(false, true, false)
 	if err != nil {
 		t.Fatal("'regolith install-all' failed:", err)
 	}
@@ -173,7 +173,7 @@ func TestInstall(t *testing.T) {
 		expectedResultPath = filepath.Join(wd, expectedResultPath)
 		// Install the filter with given version
 		err := regolith.Install(
-			[]string{filterName + "==" + version}, true, false, false, []string{"default"}, true)
+			[]string{filterName + "==" + version}, true, false, false, false, []string{"default"}, true)
 		if err != nil {
 			t.Fatal("'regolith install' failed:", err)
 		}
@@ -242,7 +242,7 @@ func TestInstallAll(t *testing.T) {
 			t.Fatal("Failed to copy config file for the test setup:", err)
 		}
 		// Run 'regolith update' / 'regolith update-all'
-		err = regolith.InstallAll(false, true)
+		err = regolith.InstallAll(false, true, false)
 		if err != nil {
 			t.Fatal("'regolith update' failed:", err)
 		}


### PR DESCRIPTION
This PR introduces a global cache for filter repositories to enhance the performance and efficiency of filter installations and version switching.

Key features included in this PR:

1. When a filter is installed, the entire repository containing the filter is cached in Regolith's app data directory. This speeds up subsequent installations and updates.
2. To switch between filter versions, the `git checkout` command is utilized, ensuring seamless version transitions.
3. By default, the cache is updated using `git fetch` after a minimum of 5 minutes has elapsed since the last update. This prevents excessive fetching and optimizes performance.
4. The cooldown duration between cache updates can be configured using the `filter_cache_update_cooldown` option in the configuration file. This allows users to fine-tune the cache update frequency based on their specific needs.
5. A forced cache refresh can be initiated by including the `--force-filter-refresh` flag when using the `install` or `install-all` subcommands.