### PR TITLE
Remove useAppData leftovers from docs

### DIFF
--- a/docs/docs/guide/configuration.md
+++ b/docs/docs/guide/configuration.md
@@ -34,10 +34,6 @@ Example config, with many options explained:
 
   // These fields are for Regolith specifically
   "regolith": {
-    // "useAppData" determines whether or not to use the app data folder, regolith should save its cache
-    // in user app data folder (true) or in the project folder in ".regolith" (false). This setting is
-    // optional and defaults to false. 
-    "useAppData": false,
     // Profiles are a list of filters and export information, which can be run with 'regolith run <profile>'
     "profiles": {
       // 'default' is the default profile. You can add more.

--- a/main.go
+++ b/main.go
@@ -112,11 +112,12 @@ be an empty directory. This command creates "config.json" and a few empty folder
 RP, BP, data, and Regolith cache (.regolith folder).
 `
 const regolithCleanDesc = `
-This command cleans the Regolith cache files for the currently opened project. With the default
-Regolith configuration, the cache of Regolith is stored in the ".regolith" folder (which you can
-find at the root of the project). When "config.json" sets the "useAppData" property to true, the
-cache is stored in the user data folder, in a path based on a hash of the project's root folder
-path. "regolith clean" always cleans both cache folders, regardless of the "useAppData" property.
+This command clears the Regolith cache files for the currently open project. With the default
+Regolith configuration, the Regolith cache is stored in the ".regolith" folder (which you can
+find in the root of the project). If your user configuration has the "use_project_app_data_storage"
+setting set to "true", the cache will be stored in the user data folder, in a path based on a hash
+of the project root path. "regolith clean" will always clean both cache folders, regardless of the
+"use_project_app_data_storage" setting.
 
 Cache files include scripts/executables of Regolith filters, their virtual environments, and a list
 of files recognized by Regolith as previous outputs.
@@ -131,9 +132,10 @@ files created by Regolith. As a safety measure, Regolith never deletes the files
 recognize so running it after "clean" would result in an error saying that Regolith stopped to
 protect your files.
 
-If you're using the "useAppData" property in your projects. It is recommended to periodically clean
-the Regolith data folder to remove the cache files of the projects that you don't work on anymore.
-You can clear caches of all projects stored in user data by using the "--user-cache" flag.
+If you're using the "use_project_app_data_storage" setting in your user configuration. It is
+recommended to periodically clean the Regolith data folder to remove the cache files of the
+projects that you don't work on anymore. You can clear caches of all projects stored in user data
+by using the "--user-cache" flag.
 `
 
 const regolithConfigDesc = `

--- a/regolith/config_unparsed.go
+++ b/regolith/config_unparsed.go
@@ -48,9 +48,3 @@ func filterDefinitionsFromConfigMap(
 ) (map[string]interface{}, error) {
 	return FindByJSONPath[map[string]interface{}](config, "regolith/filterDefinitions")
 }
-
-// useAppDataFromConfigMap returns the useAppData value from the config file
-// map, without parsing it to a Config object.
-func useAppDataFromConfigMap(config map[string]interface{}) (bool, error) {
-	return FindByJSONPath[bool](config, "regolith/useAppData")
-}


### PR DESCRIPTION
This commit removes the leftovers on unused useAppData feature from config.