### PR TITLE
Regolith 1.1.0

### DIFF
--- a/docs/docs/guide/configuration.md
+++ b/docs/docs/guide/configuration.md
@@ -34,10 +34,6 @@ Example config, with many options explained:
 
   // These fields are for Regolith specifically
   "regolith": {
-    // "useAppData" determines whether or not to use the app data folder, regolith should save its cache
-    // in user app data folder (true) or in the project folder in ".regolith" (false). This setting is
-    // optional and defaults to false. 
-    "useAppData": false,
     // Profiles are a list of filters and export information, which can be run with 'regolith run <profile>'
     "profiles": {
       // 'default' is the default profile. You can add more.

--- a/docs/docs/guide/installing-filters.md
+++ b/docs/docs/guide/installing-filters.md
@@ -112,3 +112,14 @@ Alternatively, you can use the `--force-resolver-update` flag to force the resol
 ```
 regolith install name_ninja --force-resolver-update
 ```
+
+### Updating filter cache
+
+Regolith caches the filter repository when you install online filters. To avoid unnecessary frequent updates, Regolith skips them for installations that occur less than 5 minutes after the last update.
+However, if you need to update the cache immediately, you can use the `--force-filter-update` flag while installing a filter.
+
+```bash
+regolith install name_ninja --force-filter-update
+# OR
+regolith install-all --force-filter-update
+```

--- a/docs/docs/guide/user-configuration.md
+++ b/docs/docs/guide/user-configuration.md
@@ -34,6 +34,12 @@ Default: `"5m"`
 
 The cooldown between cache updates for the resolvers. The cooldown is specified in the [Go duration format](https://pkg.go.dev/time#ParseDuration).
 
+### `filter_cache_update_cooldown: string`
+
+Default: `"5m"`
+
+The cooldown between cache updates for the filters. The cooldown is specified in the [Go duration format](https://pkg.go.dev/time#ParseDuration).
+
 ## The `regolith config` command
 
 The `regolith config` command is used to manage the user configuration of Regolith. It can access and modify

--- a/main.go
+++ b/main.go
@@ -220,7 +220,7 @@ func main() {
 
 	profiles := []string{"default"}
 	// regolith install
-	var update, resolverRefresh bool
+	var update, resolverRefresh, filterRefresh bool
 	cmdInstall := &cobra.Command{
 		Use:   "install [filters...]",
 		Short: "Downloads and installs filters from the internet and adds them to the filterDefinitions list",
@@ -230,13 +230,15 @@ func main() {
 				cmd.Help()
 				return
 			}
-			err = regolith.Install(filters, force || update, resolverRefresh, cmd.Flags().Lookup("profile").Changed, profiles, burrito.PrintStackTrace)
+			err = regolith.Install(filters, force || update, resolverRefresh, filterRefresh, cmd.Flags().Lookup("profile").Changed, profiles, burrito.PrintStackTrace)
 		},
 	}
 	cmdInstall.Flags().BoolVarP(
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
 	cmdInstall.Flags().BoolVar(
 		&resolverRefresh, "force-resolver-refresh", false, "Force resolvers refresh.")
+	cmdInstall.Flags().BoolVar(
+		&filterRefresh, "force-filter-refresh", false, "Force filter cache refresh.")
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
 	cmdInstall.Flags().StringSliceVarP(&profiles, "profile", "p", profiles, "Adds installed filters to the specified profiles. If no profile is provided, the filter will be added to the default profile.")
@@ -249,11 +251,13 @@ func main() {
 		Short: "Installs all nonexistent or outdated filters defined in filterDefinitions list",
 		Long:  regolithInstallAllDesc,
 		Run: func(cmd *cobra.Command, _ []string) {
-			err = regolith.InstallAll(force, burrito.PrintStackTrace)
+			err = regolith.InstallAll(force, burrito.PrintStackTrace, filterRefresh)
 		},
 	}
 	cmdInstallAll.Flags().BoolVarP(
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
+	cmdInstallAll.Flags().BoolVar(
+		&filterRefresh, "force-filter-refresh", false, "Force filter cache refresh.")
 	subcommands = append(subcommands, cmdInstallAll)
 
 	// regolith run
@@ -324,17 +328,20 @@ func main() {
 	subcommands = append(subcommands, cmdConfig)
 
 	// regolith clean
-	var userCache bool
+	var userCache, filterCache bool
 	cmdClean := &cobra.Command{
 		Use:   "clean",
 		Short: "Cleans Regolith cache",
 		Long:  regolithCleanDesc,
 		Run: func(cmd *cobra.Command, _ []string) {
-			err = regolith.Clean(burrito.PrintStackTrace, userCache)
+			err = regolith.Clean(burrito.PrintStackTrace, userCache, filterCache)
 		},
 	}
 	cmdClean.Flags().BoolVarP(
 		&userCache, "user-cache", "u", false, "Clears all caches stored in user data, instead of the cache of "+
+			"the current project")
+	cmdClean.Flags().BoolVar(
+		&filterCache, "filter-cache", false, "Clears filter cache stored in user data, instead of the cache of "+
 			"the current project")
 	subcommands = append(subcommands, cmdClean)
 

--- a/main.go
+++ b/main.go
@@ -112,11 +112,12 @@ be an empty directory. This command creates "config.json" and a few empty folder
 RP, BP, data, and Regolith cache (.regolith folder).
 `
 const regolithCleanDesc = `
-This command cleans the Regolith cache files for the currently opened project. With the default
-Regolith configuration, the cache of Regolith is stored in the ".regolith" folder (which you can
-find at the root of the project). When "config.json" sets the "useAppData" property to true, the
-cache is stored in the user data folder, in a path based on a hash of the project's root folder
-path. "regolith clean" always cleans both cache folders, regardless of the "useAppData" property.
+This command clears the Regolith cache files for the currently open project. With the default
+Regolith configuration, the Regolith cache is stored in the ".regolith" folder (which you can
+find in the root of the project). If your user configuration has the "use_project_app_data_storage"
+setting set to "true", the cache will be stored in the user data folder, in a path based on a hash
+of the project root path. "regolith clean" will always clean both cache folders, regardless of the
+"use_project_app_data_storage" setting.
 
 Cache files include scripts/executables of Regolith filters, their virtual environments, and a list
 of files recognized by Regolith as previous outputs.
@@ -131,9 +132,10 @@ files created by Regolith. As a safety measure, Regolith never deletes the files
 recognize so running it after "clean" would result in an error saying that Regolith stopped to
 protect your files.
 
-If you're using the "useAppData" property in your projects. It is recommended to periodically clean
-the Regolith data folder to remove the cache files of the projects that you don't work on anymore.
-You can clear caches of all projects stored in user data by using the "--user-cache" flag.
+If you're using the "use_project_app_data_storage" setting in your user configuration. It is
+recommended to periodically clean the Regolith data folder to remove the cache files of the
+projects that you don't work on anymore. You can clear caches of all projects stored in user data
+by using the "--user-cache" flag.
 `
 
 const regolithConfigDesc = `

--- a/main.go
+++ b/main.go
@@ -204,19 +204,22 @@ func main() {
 	}
 	subcommands := make([]*cobra.Command, 0)
 
+	var force bool
 	// regolith init
 	cmdInit := &cobra.Command{
 		Use:   "init",
 		Short: "Initializes a Regolith project in current directory",
 		Long:  regolithInitDesc,
 		Run: func(cmd *cobra.Command, _ []string) {
-			err = regolith.Init(burrito.PrintStackTrace)
+			err = regolith.Init(burrito.PrintStackTrace, force)
 		},
 	}
+	cmdInit.Flags().BoolVarP(
+		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
 	subcommands = append(subcommands, cmdInit)
 
 	// regolith install
-	var force, update, resolverRefresh bool
+	var update, resolverRefresh bool
 	cmdInstall := &cobra.Command{
 		Use:   "install [filters...]",
 		Short: "Downloads and installs filters from the internet and adds them to the filterDefinitions list",

--- a/main.go
+++ b/main.go
@@ -218,6 +218,7 @@ func main() {
 		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
 	subcommands = append(subcommands, cmdInit)
 
+	profiles := []string{"default"}
 	// regolith install
 	var update, resolverRefresh bool
 	cmdInstall := &cobra.Command{
@@ -229,7 +230,7 @@ func main() {
 				cmd.Help()
 				return
 			}
-			err = regolith.Install(filters, force || update, resolverRefresh, burrito.PrintStackTrace)
+			err = regolith.Install(filters, force || update, resolverRefresh, cmd.Flags().Lookup("profile").Changed, profiles, burrito.PrintStackTrace)
 		},
 	}
 	cmdInstall.Flags().BoolVarP(
@@ -238,6 +239,8 @@ func main() {
 		&resolverRefresh, "force-resolver-refresh", false, "Force resolvers refresh.")
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
+	cmdInstall.Flags().StringSliceVarP(&profiles, "profile", "p", profiles, "Adds installed filters to the specified profiles. If no profile is provided, the filter will be added to the default profile.")
+	cmdInstall.Flags().Lookup("profile").NoOptDefVal = "default"
 	subcommands = append(subcommands, cmdInstall)
 
 	// regolith install-all

--- a/regolith/config_unparsed.go
+++ b/regolith/config_unparsed.go
@@ -38,15 +38,7 @@ func LoadConfigAsMap() (map[string]interface{}, error) {
 // dataPathFromConfigMap returns the value of the data path from the config
 // file map, without parsing it to a Config object.
 func dataPathFromConfigMap(config map[string]interface{}) (string, error) {
-	regolith, ok := config["regolith"].(map[string]interface{})
-	if !ok {
-		return "", burrito.WrappedErrorf(jsonPathMissingError, "regolith")
-	}
-	dataPath, ok := regolith["dataPath"].(string)
-	if !ok {
-		return "", burrito.WrappedErrorf(jsonPathMissingError, "regolith->dataPath")
-	}
-	return dataPath, nil
+	return FindByJSONPath[string](config, "regolith/dataPath")
 }
 
 // filterDefinitionFromConfigMap returns the filter definitions as map from
@@ -54,33 +46,11 @@ func dataPathFromConfigMap(config map[string]interface{}) (string, error) {
 func filterDefinitionsFromConfigMap(
 	config map[string]interface{},
 ) (map[string]interface{}, error) {
-	regolith, ok := config["regolith"].(map[string]interface{})
-	if !ok {
-		return nil, burrito.WrappedErrorf(jsonPathMissingError, "regolith")
-	}
-	filterDefinitions, ok := regolith["filterDefinitions"].(map[string]interface{})
-	if !ok {
-		return nil, burrito.WrappedErrorf(
-			jsonPathMissingError, "regolith->filterDefinitions")
-	}
-	return filterDefinitions, nil
+	return FindByJSONPath[map[string]interface{}](config, "regolith/filterDefinitions")
 }
 
 // useAppDataFromConfigMap returns the useAppData value from the config file
 // map, without parsing it to a Config object.
 func useAppDataFromConfigMap(config map[string]interface{}) (bool, error) {
-	regolith, ok := config["regolith"].(map[string]interface{})
-	if !ok {
-		return false, burrito.WrappedErrorf(jsonPathMissingError, "regolith")
-	}
-	filterDefinitionsInterface, ok := regolith["useAppData"]
-	if !ok { // false by default
-		return false, nil
-	}
-	filterDefinitions, ok := filterDefinitionsInterface.(bool)
-	if !ok {
-		return false, burrito.WrappedErrorf(
-			jsonPathTypeError, "regolith->useAppData", "bool")
-	}
-	return filterDefinitions, nil
+	return FindByJSONPath[bool](config, "regolith/useAppData")
 }

--- a/regolith/config_unparsed.go
+++ b/regolith/config_unparsed.go
@@ -48,9 +48,3 @@ func filterDefinitionsFromConfigMap(
 ) (map[string]interface{}, error) {
 	return FindByJSONPath[map[string]interface{}](config, "regolith/filterDefinitions")
 }
-
-// useAppDataFromConfigMap returns the useAppData value from the config file
-// map, without parsing it to a Config object.
-func useAppDataFromConfigMap(config map[string]interface{}) (bool, error) {
-	return FindByJSONPath[bool](config, "regolith/useAppData")
-}

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -33,6 +33,9 @@ const (
 	// Error message displayed when os.Getwd fails
 	osGetwdError = "Failed to get current working directory."
 
+	// Error message displayed when os.Getwd fails
+	osChtimesError = "Failed to update file modification time.\nPath: %s"
+
 	// Common Error message to be reused on top of IsDirEmpty
 	isDirEmptyError = "Failed to check if path is an empty directory.\nPath: %s"
 

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -211,8 +211,12 @@ func ExportProject(
 		} else {
 			return burrito.WrapErrorf(err, osStatErrorAny, targetPath)
 		}
-		// Copy data
 		sourcePath := filepath.Join(dotRegolithPath, "tmp/data", exportedFilterName)
+		// If source path doesn't exist, skip
+		if _, err := os.Stat(sourcePath); os.IsNotExist(err) {
+			continue
+		}
+		// Copy data
 		err = revertibleOps.MoveOrCopyDir(sourcePath, targetPath)
 		if err != nil {
 			handlerError := revertibleOps.Undo()

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -3,6 +3,7 @@ package regolith
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
 )
@@ -138,7 +139,7 @@ func ExportProject(
 				"Are user permissions correct?", rpPath)
 	}
 	// List the names of the filters that opt-in to the data export process
-	exportPaths := make(map[string]struct{})
+	exportedFilterNames := []string{}
 	for filter := range profile.Filters {
 		filter := profile.Filters[filter]
 		usingDataPath, err := filter.IsUsingDataExport(dotRegolithPath)
@@ -149,13 +150,25 @@ func ExportProject(
 					"Path: %s", filter.GetId())
 		}
 		if usingDataPath {
-			exportPaths[filter.GetId()] = struct{}{}
+			// Make sure that the filter name isn't a path that tries to access
+			// files outside of the data path.
+			filterName := filter.GetId()
+			for _, forbidden := range []string{"..", "/", "\\", ":"} {
+				if strings.Contains(filterName, forbidden) {
+					// Other cases should be handled by mkdirAll
+					return burrito.WrappedErrorf(
+						"Filter name %q contains %q which is not allowed.",
+						filterName, forbidden)
+				}
+			}
+			// Add the filter name to the list of paths to export
+			exportedFilterNames = append(exportedFilterNames, filter.GetId())
 		}
 	}
 	// The root of the data path cannot be deleted because the
 	// "regolith watch" function would stop watching the file changes
 	// (due to Windows API limitation).
-	paths, err := os.ReadDir(dataPath)
+	_, err = os.ReadDir(dataPath)
 	if err != nil {
 		var err1 error = nil
 		if os.IsNotExist(err) {
@@ -174,27 +187,32 @@ func ExportProject(
 		return burrito.WrapErrorf(err, newRevertibleFsOperationsError, backupPath)
 	}
 	// Export data
-	for _, path := range paths {
-		if _, ok := exportPaths[path.Name()]; !ok {
-			// Skip the paths that are not on the list
-			continue
-		}
+	for _, exportedFilterName := range exportedFilterNames {
 		// Clear export target
-		targetPath := filepath.Join(dataPath, path.Name())
-		err = revertibleOps.DeleteDir(targetPath)
-		if err != nil {
-			handlerError := revertibleOps.Undo()
-			mainError := burrito.WrapErrorf(err, updateSourceFilesError, targetPath)
-			if handlerError != nil {
-				return burrito.GroupErrors(mainError, burrito.WrapError(handlerError, fsUndoError))
+		targetPath := filepath.Join(dataPath, exportedFilterName)
+		if _, err := os.Stat(targetPath); err == nil {
+			err = revertibleOps.DeleteDir(targetPath)
+			if err != nil {
+				handlerError := revertibleOps.Undo()
+				mainError := burrito.WrapErrorf(err, updateSourceFilesError, targetPath)
+				if handlerError != nil {
+					return burrito.GroupErrors(mainError, burrito.WrapError(handlerError, fsUndoError))
+				}
+				if handlerError := revertibleOps.Close(); handlerError != nil {
+					return burrito.GroupErrors(mainError, handlerError)
+				}
+				return mainError
 			}
-			if handlerError := revertibleOps.Close(); handlerError != nil {
-				return burrito.GroupErrors(mainError, handlerError)
+		} else if os.IsNotExist(err) {
+			err = os.MkdirAll(targetPath, 0755)
+			if err != nil {
+				return burrito.WrapErrorf(err, osMkdirError, targetPath)
 			}
-			return mainError
+		} else {
+			return burrito.WrapErrorf(err, osStatErrorAny, targetPath)
 		}
 		// Copy data
-		sourcePath := filepath.Join(dotRegolithPath, "tmp/data", path.Name())
+		sourcePath := filepath.Join(dotRegolithPath, "tmp/data", exportedFilterName)
 		err = revertibleOps.MoveOrCopyDir(sourcePath, targetPath)
 		if err != nil {
 			handlerError := revertibleOps.Undo()

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -808,9 +808,9 @@ func MoveOrCopy(
 	}
 	// Move the source to the destination
 	if err := move(source, destination); err != nil {
-		Logger.Warnf(
+		Logger.Debugf(
 			"Failed to move files.\n\tSource: %s\n\tTarget: %s\n"+
-				"This error is not critical. Trying to copy files instead...",
+				"Trying to copy files instead...",
 			filepath.Clean(source), filepath.Clean(destination))
 		copyOptions := copy.Options{PreserveTimes: false, Sync: false}
 		err := copy.Copy(source, destination, copyOptions)

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -498,6 +498,43 @@ func IsDirEmpty(path string) (bool, error) {
 	return false, nil
 }
 
+// GetMatchingDirContents returns a list of files in the directory that match the
+// ones specified in the files parameter. If the path is not a directory or
+// info about the path can't be obtained it returns an empty list and an error.
+func GetMatchingDirContents(path string, files []string) ([]string, error) {
+	result := make([]string, 0)
+	if stat, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return result, burrito.WrappedErrorf(osStatErrorIsNotExist, path)
+		}
+		return result, burrito.WrapErrorf(err, osStatErrorAny, path)
+	} else if !stat.IsDir() {
+		return result, burrito.WrappedErrorf(isDirNotADirError, path)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return result, burrito.WrapErrorf(err, osOpenError, path)
+	}
+	defer f.Close()
+	names, err := f.Readdirnames(0)
+	if err == io.EOF {
+		return result, nil
+	} else if err != nil {
+		return result, burrito.WrapErrorf(
+			err,
+			"Failed to access subdirectories list.\n"+
+				"Path: %s", path)
+	}
+	for _, name := range names {
+		// Need to use lowercase because Windows is case-insensitive
+		if stringInSlice(strings.ToLower(name), files) {
+			result = append(result, name)
+		}
+	}
+	// err is nil -> not empty
+	return result, nil
+}
+
 // AreFilesEqual compares files from two paths A and B and returns true if
 // they're equal.
 func AreFilesEqual(a, b string) (bool, error) {

--- a/regolith/install_add.go
+++ b/regolith/install_add.go
@@ -28,7 +28,7 @@ type parsedInstallFilterArg struct {
 // it returns an error unless the force flag is set.
 func installFilters(
 	filterDefinitions map[string]FilterInstaller, force bool,
-	dataPath, dotRegolithPath string, isInstall bool,
+	dataPath, dotRegolithPath string, isInstall, refreshFilters bool,
 ) error {
 	joinedPath := filepath.Join(dotRegolithPath, "cache/filters")
 	err := CreateDirectoryIfNotExists(joinedPath)
@@ -46,7 +46,7 @@ func installFilters(
 		Logger.Infof("Downloading %q filter...", name)
 		if remoteFilter, ok := filterDefinition.(*RemoteFilterDefinition); ok {
 			// Download the remote filter, and its dependencies
-			err := remoteFilter.Update(force, dotRegolithPath, isInstall)
+			err := remoteFilter.Update(force, dotRegolithPath, isInstall, refreshFilters)
 			if err != nil {
 				return burrito.WrapErrorf(err, remoteFilterDownloadError, name)
 			}

--- a/regolith/install_add.go
+++ b/regolith/install_add.go
@@ -211,11 +211,14 @@ func ListRemoteFilterTags(url, name string) ([]string, error) {
 			}
 			strippedTag := tag[len(name)+1:]
 			if semver.IsValid("v" + strippedTag) {
-				tags = append(tags, tag)
+				tags = append(tags, "v"+strippedTag)
 			}
 		}
 	}
 	semver.Sort(tags)
+	for i, tag := range tags {
+		tags[i] = name + "-" + tag[1:]
+	}
 	return tags, nil
 }
 

--- a/regolith/resolver.go
+++ b/regolith/resolver.go
@@ -108,7 +108,7 @@ func DownloadResolverMaps(forceUpdate bool) ([]string, []string, error) {
 				MeasureEnd()
 				err = os.Chtimes(cachePath, time.Now(), time.Now())
 				if err != nil {
-					Logger.Debugf("Failed to update cache file modification time.\nPath: %s", cachePath)
+					Logger.Debugf(osChtimesError, cachePath)
 				}
 				// If pull failed, delete the repo and clone it again
 				if err != nil {

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -39,6 +39,9 @@ type UserConfig struct {
 
 	// ResolverCacheUpdateCooldown is a cooldown duration, to not update resolver cache too often.
 	ResolverCacheUpdateCooldown *string `json:"resolver_cache_update_cooldown,omitempty"`
+
+	// FilterCacheUpdateCooldown is a cooldown duration, to not update resolver cache too often.
+	FilterCacheUpdateCooldown *string `json:"filter_cache_update_cooldown,omitempty"`
 }
 
 func NewUserConfig() *UserConfig {
@@ -47,6 +50,7 @@ func NewUserConfig() *UserConfig {
 		Username:                    nil,
 		Resolvers:                   []string{},
 		ResolverCacheUpdateCooldown: nil,
+		FilterCacheUpdateCooldown:   nil,
 	}
 }
 
@@ -57,6 +61,8 @@ func (u *UserConfig) String() string {
 	extra, _ = u.stringPropertyValue("resolvers")
 	result += "\n" + extra
 	extra, _ = u.stringPropertyValue("resolver_cache_update_cooldown")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("filter_cache_update_cooldown")
 	result += "\n" + extra
 	return result
 }
@@ -88,10 +94,16 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 		return result, nil
 	case "resolver_cache_update_cooldown":
 		value := "null"
-		if u.Username != nil {
+		if u.ResolverCacheUpdateCooldown != nil {
 			value = fmt.Sprintf("%v", *u.ResolverCacheUpdateCooldown)
 		}
 		return fmt.Sprintf("resolver_cache_update_cooldown: %v", value), nil
+	case "filter_cache_update_cooldown":
+		value := "null"
+		if u.FilterCacheUpdateCooldown != nil {
+			value = fmt.Sprintf("%v", *u.FilterCacheUpdateCooldown)
+		}
+		return fmt.Sprintf("filter_cache_update_cooldown: %v", value), nil
 	}
 	return "", burrito.WrapErrorf(nil, invalidUserConfigPropertyError, name)
 }
@@ -109,6 +121,10 @@ func (u *UserConfig) fillDefaults() {
 	if u.ResolverCacheUpdateCooldown == nil {
 		u.ResolverCacheUpdateCooldown = new(string)
 		*u.ResolverCacheUpdateCooldown = "5m"
+	}
+	if u.FilterCacheUpdateCooldown == nil {
+		u.FilterCacheUpdateCooldown = new(string)
+		*u.FilterCacheUpdateCooldown = "5m"
 	}
 	// Make sure resolvers is not nil and append the default resolver
 	if u.Resolvers == nil {

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -27,6 +27,10 @@ const appDataProjectCachePath = "regolith/project-cache"
 // app data
 const appDataResolverCachePath = "regolith/resolver-cache"
 
+// appDataResolverCachePath is a path to the resolver cache directory relative to the user's
+// app data
+const appDataFilterCachePath = "regolith/filter-cache"
+
 var Version = "unversioned"
 
 // nth returns the ordinal numeral of the index of a table. For example:
@@ -162,9 +166,18 @@ func LogStd(in io.ReadCloser, logFunc func(template string, args ...interface{})
 	}
 }
 
-// getResolverCache gets the dotRegolithPath from th app data folder
+// getResolverCache gets the appDataResolverCachePath from the app data folder
 func getResolverCache(resolver string) (string, error) {
 	return getAppDataCachePath(appDataResolverCachePath, resolver)
+}
+
+// getFilterCache gets the appDataFilterCachePath from the app data folder
+func getFilterCache(url string) (string, error) {
+	path, err := getAppDataCachePath(appDataFilterCachePath, url)
+	if err == nil {
+		Logger.Debugf("Regolith filter cache for %s is in:\n\t%s", url, path)
+	}
+	return path, err
 }
 
 // getAppDataCachePath gets the dotRegolithPath from th app data folder
@@ -185,7 +198,7 @@ func getAppDataCachePath(basePath, cacheId string) (string, error) {
 	return cachePath, nil
 }
 
-// getAppDataDotRegolith gets the dotRegolithPath from th app data folder
+// getAppDataDotRegolith gets the dotRegolithPath from the app data folder
 func getAppDataDotRegolith(projectRoot string) (string, error) {
 	// Make sure that projectsRoot is an absolute path
 	absoluteProjectRoot, err := filepath.Abs(projectRoot)

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -334,4 +335,98 @@ func stringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// FindByJSONPath finds a value in a JSON element by a simple path. Returns nil and an error if the path is not found or invalid.
+func FindByJSONPath[T any](obj interface{}, path string) (T, error) {
+	var empty T
+	if obj == nil {
+		return empty, burrito.WrappedErrorf("Object is empty")
+	}
+	// Split the path into parts
+	parts, err := splitEscapedString(path)
+	if err != nil {
+		return empty, burrito.WrapErrorf(err, "Invalid path %s", path)
+	}
+	// Find the value
+	value := obj
+	currentPath := ""
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		currentPath += part + "->"
+		if m, ok := value.(map[string]interface{}); ok {
+			value = m[part]
+			if value == nil {
+				return empty, burrito.WrappedErrorf(jsonPathMissingError, currentPath[:len(currentPath)-2])
+			}
+			continue
+		}
+		if a, ok := value.([]interface{}); ok {
+			index, err := strconv.Atoi(part)
+			if err != nil {
+				return empty, burrito.WrapErrorf(err, "Invalid index %s at %s", part, currentPath[:len(currentPath)-2])
+			}
+			if index < 0 || index >= len(a) {
+				return empty, burrito.WrappedErrorf("Index %i is out of bounds at %s", index, currentPath[:len(currentPath)-2])
+			}
+			value = a[index]
+			if value == nil {
+				return empty, burrito.WrappedErrorf(jsonPathMissingError, currentPath[:len(currentPath)-2])
+			}
+			continue
+		}
+		return empty, burrito.WrappedErrorf(jsonPathTypeError, currentPath[:len(currentPath)-2], "object or array")
+	}
+	if s, ok := value.(T); ok {
+		return s, nil
+	}
+	return empty, burrito.WrappedErrorf(jsonPathTypeError, path, reflect.TypeOf(empty).String())
+}
+
+func splitEscapedString(s string) ([]string, error) {
+	parts := make([]string, 0)
+	var sb strings.Builder
+	escape := false
+	for _, c := range s {
+		if escape {
+			if c != '\\' && c != '/' {
+				return nil, burrito.WrappedErrorf("Invalid escape sequence \\%c", c)
+			}
+			sb.WriteRune(c)
+			escape = false
+			continue
+		}
+		if c == '\\' {
+			escape = true
+			continue
+		}
+		if c == '/' {
+			if sb.String() != "" {
+				parts = append(parts, sb.String())
+			}
+			sb.Reset()
+			continue
+		}
+		sb.WriteRune(c)
+	}
+	if escape {
+		return nil, burrito.WrappedErrorf("Invalid escape sequence \\")
+	}
+	if sb.String() != "" {
+		parts = append(parts, sb.String())
+	}
+	return parts, nil
+}
+
+func EscapePathPart(s string) string {
+	var sb strings.Builder
+	for _, c := range s {
+		if c == '\\' || c == '/' {
+			sb.WriteRune('\\')
+		}
+		sb.WriteRune(c)
+	}
+	return sb.String()
 }

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -326,3 +326,12 @@ func MeasureEnd() {
 	Logger.Infof("%s took %s (%s)", lastMeasure.Name, duration, lastMeasure.Location)
 	lastMeasure = nil
 }
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/test/json_path_test.go
+++ b/test/json_path_test.go
@@ -1,0 +1,122 @@
+package test
+
+import (
+	"github.com/Bedrock-OSS/go-burrito/burrito"
+	"github.com/Bedrock-OSS/regolith/regolith"
+	"testing"
+)
+
+func TestSimplePath(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": "bar",
+	}
+	expected := "bar"
+	actual, err := regolith.FindByJSONPath[string](obj, "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestSimplePath2(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": []interface{}{"bar"},
+	}
+	expected := "bar"
+	actual, err := regolith.FindByJSONPath[string](obj, "foo/0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestSimplePath3(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+	expected := "baz"
+	actual, err := regolith.FindByJSONPath[string](obj, "foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestEscapedPath(t *testing.T) {
+	obj := map[string]interface{}{
+		"fo/o": "bar",
+	}
+	expected := "bar"
+	actual, err := regolith.FindByJSONPath[string](obj, "fo\\/o")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestEscapedPath2(t *testing.T) {
+	obj := map[string]interface{}{
+		"fo/o": "bar",
+	}
+	expected := "bar"
+	actual, err := regolith.FindByJSONPath[string](obj, regolith.EscapePathPart("fo/o"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestInvalidPath(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+	expected := "Invalid data type.\nJSON Path: foo->bar->baz\nExpected type: object or array"
+	_, err := regolith.FindByJSONPath[string](obj, "foo/bar/baz")
+	if err == nil {
+		t.Fatal("Expected an error, got nil")
+	}
+	if burrito.GetAllMessages(err)[0] != expected {
+		t.Fatalf("Expected error %v, got %v", expected, burrito.GetAllMessages(err)[0])
+	}
+}
+
+func TestInvalidPath2(t *testing.T) {
+	obj := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+	expected := "Required JSON path is missing.\nJSON Path: foo->0"
+	_, err := regolith.FindByJSONPath[string](obj, "foo/0/baz")
+	if err == nil {
+		t.Fatal("Expected an error, got nil")
+	}
+	if burrito.GetAllMessages(err)[0] != expected {
+		t.Fatalf("Expected error %v, got %v", expected, burrito.GetAllMessages(err)[0])
+	}
+}
+
+func TestNullObject(t *testing.T) {
+	expected := "Object is empty"
+	_, err := regolith.FindByJSONPath[string](nil, "foo/bar/baz")
+	if err == nil {
+		t.Fatal("Expected an error, got nil")
+	}
+	if burrito.GetAllMessages(err)[0] != expected {
+		t.Fatalf("Expected error %v, got %v", expected, burrito.GetAllMessages(err)[0])
+	}
+}

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -39,7 +39,7 @@ func TestRegolithInit(t *testing.T) {
 		t.Fatal("Unable to change working directory:", err.Error())
 	}
 	// THE TEST
-	err = regolith.Init(true)
+	err = regolith.Init(true, false)
 	if err != nil {
 		t.Fatal("'regolith init' failed:", err.Error())
 	}

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -124,7 +124,7 @@ func TestLocalRequirementsInstallAndRun(t *testing.T) {
 	// Switch to the working directory
 	os.Chdir(filepath.Join(tmpDir, "project"))
 	// THE TEST
-	err = regolith.InstallAll(false, true)
+	err = regolith.InstallAll(false, true, false)
 	if err != nil {
 		t.Fatal("'regolith install-all' failed", err.Error())
 	}

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -54,7 +54,7 @@ func TestInstallAllAndRun(t *testing.T) {
 	os.Chdir(workingDir)
 	// THE TEST
 	// Run InstallDependencies
-	err = regolith.InstallAll(false, true)
+	err = regolith.InstallAll(false, true, false)
 	if err != nil {
 		t.Fatal("'regolith install-all' failed:", err)
 	}
@@ -116,7 +116,7 @@ func TestDataModifyRemoteFilter(t *testing.T) {
 	os.Chdir(workingDir)
 	// THE TEST
 	// Run InstallDependencies
-	err = regolith.InstallAll(false, true)
+	err = regolith.InstallAll(false, true, false)
 	if err != nil {
 		t.Fatal("'regolith install-all' failed:", err)
 	}
@@ -173,7 +173,7 @@ func TestInstall(t *testing.T) {
 		expectedResultPath = filepath.Join(wd, expectedResultPath)
 		// Install the filter with given version
 		err := regolith.Install(
-			[]string{filterName + "==" + version}, true, false, false, []string{"default"}, true)
+			[]string{filterName + "==" + version}, true, false, false, false, []string{"default"}, true)
 		if err != nil {
 			t.Fatal("'regolith install' failed:", err)
 		}
@@ -242,7 +242,7 @@ func TestInstallAll(t *testing.T) {
 			t.Fatal("Failed to copy config file for the test setup:", err)
 		}
 		// Run 'regolith update' / 'regolith update-all'
-		err = regolith.InstallAll(false, true)
+		err = regolith.InstallAll(false, true, false)
 		if err != nil {
 			t.Fatal("'regolith update' failed:", err)
 		}

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -173,7 +173,7 @@ func TestInstall(t *testing.T) {
 		expectedResultPath = filepath.Join(wd, expectedResultPath)
 		// Install the filter with given version
 		err := regolith.Install(
-			[]string{filterName + "==" + version}, true, false, true)
+			[]string{filterName + "==" + version}, true, false, false, []string{"default"}, true)
 		if err != nil {
 			t.Fatal("'regolith install' failed:", err)
 		}


### PR DESCRIPTION
 - Added caching filter repos
 - Added `filter_cache_update_cooldown` option in configuration file
 - Added a forced cache refresh withy `--force-filter-refresh` flag when using `install` and `install-all` subcommands
 - Added `--profile` flag to `install` subcommand for automatically adding installed filter to a profile
 - Fixed not exporting data when data folder doesn't exist (Fixes #249)
 - Fixed crash, when filter used `exportData` property
 - Fixed incorrect sorting of the tags when searching for the latest version