### PR TITLE
Add env variable com.mojang support for non-Windows OS

### DIFF
--- a/regolith/compatibility_other_os.go
+++ b/regolith/compatibility_other_os.go
@@ -3,7 +3,10 @@
 
 package regolith
 
-import "github.com/Bedrock-OSS/go-burrito/burrito"
+import (
+	"os"
+	"github.com/Bedrock-OSS/go-burrito/burrito"
+)
 
 // pythonExeNames is the list of strings with possible names of the Python
 // executable. The order of the names determines the order in which they are
@@ -48,11 +51,19 @@ func (d *DirWatcher) Close() error {
 }
 
 func FindMojangDir() (string, error) {
-	return "", burrito.WrappedError(notImplementedOnThisSystemError)
+	comMojang := os.Getenv("COM_MOJANG")
+	if comMojang == "" {
+			return "", burrito.WrappedError(comMojangEnvUnsetError)
+	}
+	return comMojang, nil
 }
 
 func FindPreviewDir() (string, error) {
-	return "", burrito.WrappedError(notImplementedOnThisSystemError)
+	comMojangPreview := os.Getenv("COM_MOJANG_PREVIEW")
+	if comMojangPreview == "" {
+			return "", burrito.WrappedError(comMojangPreviewEnvUnsetError)
+	}
+	return comMojangPreview, nil
 }
 
 func CheckSuspiciousLocation() error {

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -143,6 +143,12 @@ const (
 	// Error used when certain function is not implemented on this system
 	notImplementedOnThisSystemError = "Not implemented for this system."
 
+	// Error used when env variable COM_MOJANG is not set on non Windows system
+	comMojangEnvUnsetError = "COM_MOJANG environment variable is not set."
+
+	// Error used when env variable COM_MOJANG_PREVIEW is not set on non Windows system
+	comMojangPreviewEnvUnsetError = "COM_MOJANG_PREVIEW environment variable is not set."
+
 	// Error used when SetupTmpFiles function fails
 	setupTmpFilesError = "Failed to setup temporary files.\n" +
 		"Regolith files path: %s" // .regolith


### PR DESCRIPTION
This fixes #260 as somewhat of a workaround and provides users on non-Windows operating systems the ability to define the following environment variables for use with `development` and `preview` export targets:

`COM_MOJANG` -> provides the path to the com.mojang directory (non-preview)
`COM_MOJANG_PREVIEW` -> provides the path to the com.mojang directory (preview)

Additionally, two new error messages have been added to inform a non-Windows user attempting to compile using either of these export targets that they must set the corresponding environment variable.