### PR TITLE
Update README.md to link to installation doc from guide instead of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 **This setup is for developers. If you're a normal user, you can find simpler
 instructions
-[here](https://bedrock-oss.github.io/regolith/docs/installing).**
+[here](https://bedrock-oss.github.io/regolith/guide/installing).**
 
 ### 1. Install Golang
 


### PR DESCRIPTION
# Issue
Current link at line 34 to installation guide links to a 404 page,


# Fix
Updated link to the installation guide from
`https://bedrock-oss.github.io/regolith/docs/installing`
to
`https://bedrock-oss.github.io/regolith/guide/installing`