### PR TITLE
Move copying data before installing dependencies

### DIFF
--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -547,7 +547,7 @@ func (f *RemoteFilterDefinition) InstalledVersion(dotRegolithPath string) (strin
 	return versionStr, nil
 }
 
-func (f *RemoteFilterDefinition) Update(force bool, dotRegolithPath string, refreshFilters bool) error {
+func (f *RemoteFilterDefinition) Update(force bool, dotRegolithPath, dataPath string, refreshFilters bool) error {
 	installedVersion, err := f.InstalledVersion(dotRegolithPath)
 	installedVersion = trimFilterPrefix(installedVersion, f.Id)
 	if err != nil && force {
@@ -569,6 +569,8 @@ func (f *RemoteFilterDefinition) Update(force bool, dotRegolithPath string, refr
 		if err != nil {
 			return burrito.PassError(err)
 		}
+		// Copy the data of the remote filter to the data path
+		f.CopyFilterData(dataPath, dotRegolithPath)
 		err = f.InstallDependencies(f, dotRegolithPath)
 		if err != nil {
 			return burrito.PassError(err)

--- a/regolith/install_add.go
+++ b/regolith/install_add.go
@@ -48,12 +48,10 @@ func installFilters(
 		Logger.Infof("Downloading %q filter...", name)
 		if remoteFilter, ok := filterDefinition.(*RemoteFilterDefinition); ok {
 			// Download the remote filter, and its dependencies
-			err := remoteFilter.Update(force, dotRegolithPath, refreshFilters)
+			err := remoteFilter.Update(force, dotRegolithPath, dataPath, refreshFilters)
 			if err != nil {
 				return burrito.WrapErrorf(err, remoteFilterDownloadError, name)
 			}
-			// Copy the data of the remote filter to the data path
-			remoteFilter.CopyFilterData(dataPath, dotRegolithPath)
 		} else {
 			// Non-remote filters must always update their dependencies.
 			// TODO - add option to track if the filter already installed


### PR DESCRIPTION
This PR moves copying remote filter data (the default data) before installing dependencies. Fixes #280 