### PR TITLE
Fixed exporting files to the data folder using nested profiles.

### DIFF
--- a/regolith/export.go
+++ b/regolith/export.go
@@ -200,7 +200,7 @@ func ExportProject(ctx RunContext) error {
 	var exportedFilterNames []string
 	for filter := range profile.Filters {
 		filter := profile.Filters[filter]
-		usingDataPath, err := filter.IsUsingDataExport(dotRegolithPath)
+		usingDataPath, err := filter.IsUsingDataExport(dotRegolithPath, ctx)
 		if err != nil {
 			return burrito.WrapErrorf(
 				err,

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -215,7 +215,7 @@ type FilterRunner interface {
 
 	// IsUsingDataExport returns whether the filter wants its data to be
 	// exported back to the data folder after running the profile.
-	IsUsingDataExport(dotRegolithPath string) (bool, error)
+	IsUsingDataExport(dotRegolithPath string, ctx RunContext) (bool, error)
 }
 
 func (f *Filter) CopyArguments(parent *RemoteFilter) {
@@ -256,7 +256,7 @@ func (f *Filter) IsDisabled(ctx RunContext) (bool, error) {
 	return false, nil
 }
 
-func (f *Filter) IsUsingDataExport(_ string) (bool, error) {
+func (f *Filter) IsUsingDataExport(_ string, _ RunContext) (bool, error) {
 	return false, nil
 }
 

--- a/regolith/filter_profile.go
+++ b/regolith/filter_profile.go
@@ -40,3 +40,21 @@ func (f *ProfileFilter) Check(context RunContext) error {
 		profile, f.Profile, *context.Config, &context,
 		context.DotRegolithPath)
 }
+
+func (f *ProfileFilter) IsUsingDataExport(dotRegolithPath string, ctx RunContext) (bool, error) {
+	profile := ctx.Config.Profiles[f.Profile]
+	for filter := range profile.Filters {
+		filter := profile.Filters[filter]
+		usingDataPath, err := filter.IsUsingDataExport(dotRegolithPath, ctx)
+		if err != nil {
+			return false, burrito.WrapErrorf(
+				err,
+				"Failed to check if profile is using data export.\n"+
+					"Profile: %s", f.Profile)
+		}
+		if usingDataPath {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -308,7 +308,7 @@ func (f *RemoteFilter) GetCachedVersion(dotRegolithPath string) (*string, error)
 	return &version, nil
 }
 
-func (f *RemoteFilter) IsUsingDataExport(dotRegolithPath string) (bool, error) {
+func (f *RemoteFilter) IsUsingDataExport(dotRegolithPath string, _ RunContext) (bool, error) {
 	// Load the filter.json file
 	filterJsonPath := filepath.Join(f.GetDownloadPath(dotRegolithPath), "filter.json")
 	file, err := os.ReadFile(filterJsonPath)


### PR DESCRIPTION
This PR fixes the issue that cause the profile filters not being correctly classified as filters that modify the data files. Now, a profile filter checks if any of its subfilters modifies the `data` folder to determine whether the data folder should be exported back or not at the end of the `regolith run` execution.