### PR TITLE
Handle errors during file watching

### DIFF
--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -297,7 +297,10 @@ func Watch(profileName string, debug bool) error {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	// Run the profile
-	context.StartWatchingSourceFiles()
+	err = context.StartWatchingSourceFiles()
+	if err != nil {
+		return burrito.PassError(err)
+	}
 	for { // Loop until program termination (CTRL+C)
 		err = RunProfile(*context)
 		if err != nil {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -316,6 +316,10 @@ func Watch(profileName string, debug bool) error {
 			// AwaitInterruption locks the goroutine with the interruption channel until
 			// the Config is interrupted and returns the interruption message.
 			Logger.Warn("Restarting...")
+		case err := <-context.fileWatchingErrorChannel:
+			if err != nil {
+				return burrito.WrapError(err, "Encountered an error during file watching")
+			}
 		case <-sigChan:
 			return sessionLockErr // Return the error from the defer function
 		}


### PR DESCRIPTION
This PR fixes Regolith not reporting errors that may occur when starting to watch source files.

Additionally, it adds a channel to allow passing errors from the file watching goroutines. This ensures Regolith will stop upon encountering any errors during watch mode.