### PR TITLE
The replace_node_with_deno and replace_node_with_bun experiments

### DIFF
--- a/regolith/experiments.go
+++ b/regolith/experiments.go
@@ -7,6 +7,8 @@ const (
 	SizeTimeCheck Experiment = iota
 	// ReplaceNodeWithDeno is an experiment that makes the NodeJS filters run using Deno
 	ReplaceNodeWithDeno
+	// ReplaceNodeWithBun is an experiment that makes the NodeJS filters run using Bun
+	ReplaceNodeWithBun
 )
 
 // The descriptions shouldn't be too wide, the text with their description is
@@ -22,6 +24,10 @@ Runs the NodeJS filters using Deno. For this to work, you need to have
 Deno version 2.0.0 or higher installed.
 `
 
+const replaceNodeWithBunDesc = `
+Runs the NodeJS filters using Bun.
+`
+
 type ExperimentInfo struct {
 	Name        string
 	Description string
@@ -30,6 +36,7 @@ type ExperimentInfo struct {
 var AvailableExperiments = map[Experiment]ExperimentInfo{
 	SizeTimeCheck:       {"size_time_check", sizeTimeCheckDesc},
 	ReplaceNodeWithDeno: {"replace_node_with_deno", replaceNodeWithDenoDesc},
+	ReplaceNodeWithBun:  {"replace_node_with_bun", replaceNodeWithBunDesc},
 }
 
 var EnabledExperiments []string

--- a/regolith/experiments.go
+++ b/regolith/experiments.go
@@ -5,6 +5,8 @@ type Experiment int
 const (
 	// SizeTimeCheck is an experiment that checks the size and modification time when exporting
 	SizeTimeCheck Experiment = iota
+	// ReplaceNodeWithDeno is an experiment that makes the NodeJS filters run using Deno
+	ReplaceNodeWithDeno
 )
 
 // The descriptions shouldn't be too wide, the text with their description is
@@ -15,6 +17,10 @@ modification time of files before exporting, and only exporting if
 the file has changed. This experiment applies to 'run' and 'watch'
 commands.
 `
+const replaceNodeWithDenoDesc = `
+Runs the NodeJS filters using Deno. For this to work, you need to have
+Deno version 2.0.0 or higher installed.
+`
 
 type ExperimentInfo struct {
 	Name        string
@@ -22,7 +28,8 @@ type ExperimentInfo struct {
 }
 
 var AvailableExperiments = map[Experiment]ExperimentInfo{
-	SizeTimeCheck: {"size_time_check", sizeTimeCheckDesc},
+	SizeTimeCheck:       {"size_time_check", sizeTimeCheckDesc},
+	ReplaceNodeWithDeno: {"replace_node_with_deno", replaceNodeWithDenoDesc},
 }
 
 var EnabledExperiments []string


### PR DESCRIPTION
This experiment allows running NodeJS filters using Deno or Bun.

Limitations of using Deno:
- Deno 2.0.0 or higher (as of this writing it's v2 is a release canditate, not an offical release).
- The filter must be a ES Module. The CommonJS format doesn't work (perhaps I missed some solution here).

Limitations of using Bun:
- None as far as I can tell.

Some helpful related resources:
- About Deno V2: https://docs.deno.com/runtime/reference/migrate_deprecations/
- Updating CommanJS to ESM https://docs.deno.com/runtime/tutorials/cjs_to_esm/
- Example filter that works with the flag active: https://github.com/Nusiq/regolith-filters/commit/dc397dd237518bb3464b9ba0fdf1d646398e1712
- Bun website: https://bun.sh/