### PR TITLE
Optimizations

### DIFF
--- a/main.go
+++ b/main.go
@@ -335,6 +335,7 @@ func main() {
 		Long:  regolithConfigDesc,
 		Run: func(cmd *cobra.Command, args []string) {
 			regolith.InitLogging(burrito.PrintStackTrace)
+			defer regolith.ShutdownLogging()
 			full, _ := cmd.Flags().GetBool("full")
 			delete, _ := cmd.Flags().GetBool("delete")
 			append, _ := cmd.Flags().GetBool("append")

--- a/regolith/compare_filepaths_test.go
+++ b/regolith/compare_filepaths_test.go
@@ -1,0 +1,22 @@
+package regolith
+
+import "testing"
+
+func TestCompareFilePaths(t *testing.T) {
+	tests := []struct {
+		a, b     string
+		expected int
+	}{
+		{"text/text.txt", "text.txt", -1},
+		{"text.txt", "text/text.txt", 1},
+		{"abc/a.txt", "abc/b.txt", -1},
+		{"abc/b.txt", "abc/a.txt", 1},
+		{"abc\\b.txt", "abc/b.txt", 0},
+		{"same/path.txt", "same/path.txt", 0},
+	}
+	for _, tt := range tests {
+		if got := compareFilePaths(tt.a, tt.b); got != tt.expected {
+			t.Errorf("compareFilePaths(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.expected)
+		}
+	}
+}

--- a/regolith/experiments.go
+++ b/regolith/experiments.go
@@ -5,6 +5,9 @@ type Experiment int
 const (
 	// SizeTimeCheck is an experiment that checks the size and modification time when exporting
 	SizeTimeCheck Experiment = iota
+	// SymlinkExport links the temporary build directory with the export
+	// target using hard links when possible.
+	SymlinkExport
 )
 
 // The descriptions shouldn't be too wide, the text with their description is
@@ -16,6 +19,10 @@ the file has changed. This experiment applies to 'run' and 'watch'
 commands.
 `
 
+const symlinkExportDesc = `
+Creates links from the tmp directory to the export target so that files
+written to tmp are immediately reflected in the export location.`
+
 type ExperimentInfo struct {
 	Name        string
 	Description string
@@ -23,6 +30,7 @@ type ExperimentInfo struct {
 
 var AvailableExperiments = map[Experiment]ExperimentInfo{
 	SizeTimeCheck: {"size_time_check", sizeTimeCheckDesc},
+	SymlinkExport: {"symlink_export", symlinkExportDesc},
 }
 
 var EnabledExperiments []string

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -334,7 +334,7 @@ func ExportProject(ctx RunContext) error {
 		// Clear export target
 		targetPath := filepath.Join(dataPath, exportedFilterName)
 		if _, err := os.Stat(targetPath); err == nil {
-			err = revertibleOps.DeleteDir(targetPath)
+			err = revertibleOps.Delete(targetPath)
 			if err != nil {
 				handlerError := revertibleOps.Undo()
 				mainError := burrito.WrapErrorf(err, updateSourceFilesError, targetPath)
@@ -477,7 +477,7 @@ func InplaceExportProject(
 		config.ResourceFolder, config.BehaviorFolder, config.DataPath}
 	for _, deleteDir := range deleteDirs {
 		if deleteDir != "" {
-			err = revertibleOps.DeleteDir(deleteDir)
+			err = revertibleOps.Delete(deleteDir)
 			if err != nil {
 				err = burrito.WrapErrorf(
 					err, updateSourceFilesError, deleteDir)

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -16,7 +16,8 @@ import (
 	"github.com/otiai10/copy"
 )
 
-const copyFileBufferSize = 1_000_000 // 1 MB
+// According to the internet, the buffer size should be around 4kB.
+const copyFileBufferSize = 4096
 
 // revertibleFsOperations is a struct that performs file system operations,
 // keeps track of them, and can undo them if something goes wrong.

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -16,8 +16,8 @@ import (
 	"github.com/otiai10/copy"
 )
 
-// According to the internet, the buffer size should be around 4kB.
-const copyFileBufferSize = 4096
+// According to the internet, the buffer size should be around 128kB.
+const copyFileBufferSize = 128 * 1024 // 128kB
 
 // revertibleFsOperations is a struct that performs file system operations,
 // keeps track of them, and can undo them if something goes wrong.

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -226,82 +226,77 @@ func (f *Filter) IsUsingDataExport(_ string, _ RunContext) (bool, error) {
 	return false, nil
 }
 
+type filterInstallerFactory struct {
+	constructor func(string, map[string]interface{}) (FilterInstaller, error)
+	name        string
+}
+
+var filterInstallerFactories = map[string]filterInstallerFactory{
+	"java": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return JavaFilterDefinitionFromObject(id, obj)
+		},
+		name: "Java",
+	},
+	"dotnet": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return DotNetFilterDefinitionFromObject(id, obj)
+		},
+		name: ".Net",
+	},
+	"nim": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return NimFilterDefinitionFromObject(id, obj)
+		},
+		name: "Nim",
+	},
+	"deno": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return DenoFilterDefinitionFromObject(id, obj)
+		},
+		name: "Deno",
+	},
+	"nodejs": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return NodeJSFilterDefinitionFromObject(id, obj)
+		},
+		name: "NodeJs",
+	},
+	"python": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return PythonFilterDefinitionFromObject(id, obj)
+		},
+		name: "Python",
+	},
+	"shell": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return ShellFilterDefinitionFromObject(id, obj)
+		},
+		name: "shell",
+	},
+	"exe": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return ExeFilterDefinitionFromObject(id, obj)
+		},
+		name: "exe",
+	},
+	"": {
+		constructor: func(id string, obj map[string]interface{}) (FilterInstaller, error) {
+			return RemoteFilterDefinitionFromObject(id, obj)
+		},
+		name: "remote",
+	},
+}
+
 func FilterInstallerFromObject(id string, obj map[string]interface{}) (FilterInstaller, error) {
 	runWith, _ := obj["runWith"].(string)
-	switch runWith {
-	case "java":
-		filter, err := JavaFilterDefinitionFromObject(id, obj)
+	if factory, ok := filterInstallerFactories[runWith]; ok {
+		filter, err := factory.constructor(id, obj)
 		if err != nil {
 			return nil, burrito.WrapErrorf(
 				err,
-				"Unable to create Java filter from %q filter definition.", id)
-		}
-		return filter, nil
-	case "dotnet":
-		filter, err := DotNetFilterDefinitionFromObject(id, obj)
-		if err != nil {
-			return nil, burrito.WrapErrorf(
-				err,
-				"Unable to create .Net filter from %q filter definition.", id)
-		}
-		return filter, nil
-	case "nim":
-		filter, err := NimFilterDefinitionFromObject(id, obj)
-		if err != nil {
-			return nil, burrito.WrapErrorf(
-				err,
-				"Unable to create Nim filter from %q filter definition.", id)
-		}
-		return filter, nil
-	case "deno":
-		filter, err := DenoFilterDefinitionFromObject(id, obj)
-		if err != nil {
-			return nil, burrito.WrapErrorf(
-				err,
-				"Unable to create Deno filter from %q filter definition.", id)
-		}
-		return filter, nil
-	case "nodejs":
-		filter, err := NodeJSFilterDefinitionFromObject(id, obj)
-		if err != nil {
-			return nil, burrito.WrapErrorf(
-				err,
-				"Unable to create NodeJs filter from %q filter definition.",
-				id)
-		}
-		return filter, nil
-	case "python":
-		filter, err := PythonFilterDefinitionFromObject(id, obj)
-		if err != nil {
-			return nil, burrito.WrapErrorf(
-				err,
-				"Unable to create Python filter from %q filter definition.",
-				id)
-		}
-		return filter, nil
-	case "shell":
-		filter, err := ShellFilterDefinitionFromObject(id, obj)
-		if err != nil {
-			return nil, burrito.WrapErrorf(
-				err,
-				"Unable to create shell filter from %q filter definition.", id)
-		}
-		return filter, nil
-	case "exe":
-		filter, err := ExeFilterDefinitionFromObject(id, obj)
-		if err != nil {
-			return nil, burrito.WrapErrorf(
-				err,
-				"Unable to create exe filter from %q filter definition.", id)
-		}
-		return filter, nil
-	case "":
-		filter, err := RemoteFilterDefinitionFromObject(id, obj)
-		if err != nil {
-			return nil, burrito.WrapErrorf(
-				err,
-				"Unable to create remote filter from %q filter definition.",
-				id)
+				"Unable to create %s filter from %q filter definition.",
+				factory.name, id)
 		}
 		return filter, nil
 	}

--- a/regolith/filter_deno.go
+++ b/regolith/filter_deno.go
@@ -79,8 +79,8 @@ func (f *DenoFilter) Run(context RunContext) (bool, error) {
 	return context.IsInterrupted(), nil
 }
 
-func (f *DenoFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+func (f *DenoFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}, id string) (FilterRunner, error) {
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}

--- a/regolith/filter_dotnet.go
+++ b/regolith/filter_dotnet.go
@@ -78,8 +78,8 @@ func (f *DotNetFilter) run(context RunContext) error {
 	return nil
 }
 
-func (f *DotNetFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+func (f *DotNetFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}, id string) (FilterRunner, error) {
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}

--- a/regolith/filter_exe.go
+++ b/regolith/filter_exe.go
@@ -44,9 +44,9 @@ func (f *ExeFilter) Run(context RunContext) (bool, error) {
 }
 
 func (f *ExeFilterDefinition) CreateFilterRunner(
-	runConfiguration map[string]interface{},
+	runConfiguration map[string]interface{}, id string,
 ) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}

--- a/regolith/filter_java.go
+++ b/regolith/filter_java.go
@@ -90,8 +90,8 @@ func (f *JavaFilter) run(context RunContext) error {
 	return nil
 }
 
-func (f *JavaFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+func (f *JavaFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}, id string) (FilterRunner, error) {
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}

--- a/regolith/filter_nim.go
+++ b/regolith/filter_nim.go
@@ -2,6 +2,7 @@ package regolith
 
 import (
 	"encoding/json"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -173,8 +174,8 @@ func (f *NimFilter) Check(context RunContext) error {
 
 func hasNimble(filterPath string) bool {
 	nimble := false
-	filepath.Walk(filterPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
+	filepath.WalkDir(filterPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
 			return nil
 		}
 		if filepath.Ext(path) == ".nimble" {

--- a/regolith/filter_nim.go
+++ b/regolith/filter_nim.go
@@ -97,8 +97,8 @@ func (f *NimFilter) Run(context RunContext) (bool, error) {
 	return context.IsInterrupted(), nil
 }
 
-func (f *NimFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+func (f *NimFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}, id string) (FilterRunner, error) {
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}

--- a/regolith/filter_nodejs.go
+++ b/regolith/filter_nodejs.go
@@ -93,8 +93,8 @@ func (f *NodeJSFilter) Run(context RunContext) (bool, error) {
 	return context.IsInterrupted(), nil
 }
 
-func (f *NodeJSFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+func (f *NodeJSFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}, id string) (FilterRunner, error) {
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}

--- a/regolith/filter_python.go
+++ b/regolith/filter_python.go
@@ -109,8 +109,8 @@ func (f *PythonFilter) Run(context RunContext) (bool, error) {
 	return context.IsInterrupted(), nil
 }
 
-func (f *PythonFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+func (f *PythonFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}, id string) (FilterRunner, error) {
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}

--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -128,8 +128,8 @@ func (f *RemoteFilter) Run(context RunContext) (bool, error) {
 	return context.IsInterrupted(), nil
 }
 
-func (f *RemoteFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+func (f *RemoteFilterDefinition) CreateFilterRunner(runConfiguration map[string]interface{}, id string) (FilterRunner, error) {
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}
@@ -187,7 +187,7 @@ func (f *RemoteFilterDefinition) InstallDependencies(_ *RemoteFilterDefinition, 
 
 func (f *RemoteFilterDefinition) Check(context RunContext) error {
 	dummyFilterRunner, err := f.CreateFilterRunner(
-		map[string]interface{}{"filter": f.Id})
+		map[string]interface{}{}, f.Id)
 	const shouldntHappenError = "Filter name: %s\n" +
 		"This is a bug, please submit a bug report to the Regolith " +
 		"project repository:\n" +

--- a/regolith/filter_shell.go
+++ b/regolith/filter_shell.go
@@ -44,9 +44,9 @@ func (f *ShellFilter) Run(context RunContext) (bool, error) {
 }
 
 func (f *ShellFilterDefinition) CreateFilterRunner(
-	runConfiguration map[string]interface{},
+	runConfiguration map[string]interface{}, id string,
 ) (FilterRunner, error) {
-	basicFilter, err := filterFromObject(runConfiguration)
+	basicFilter, err := filterFromObject(runConfiguration, id)
 	if err != nil {
 		return nil, burrito.WrapError(err, filterFromObjectError)
 	}

--- a/regolith/logging.go
+++ b/regolith/logging.go
@@ -95,6 +95,13 @@ func InitLogging(dev bool) {
 			},
 		},
 	}.Build()
-	defer logger.Sync() // flushes buffer, if any
 	Logger = logger.Sugar()
+}
+
+// ShutdownLogging flushes any buffered log entries. It should be called
+// before the program exits.
+func ShutdownLogging() {
+	if Logger != nil {
+		_ = Logger.Sync()
+	}
 }

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -41,6 +41,7 @@ var disallowedFiles = []string{
 // should be printed.
 func Install(filters []string, force, refreshResolvers, refreshFilters bool, profiles []string, debug bool) error {
 	InitLogging(debug)
+	defer ShutdownLogging()
 	Logger.Info("Installing filters...")
 	if !hasGit() {
 		Logger.Warn(gitNotInstalledWarning)
@@ -147,6 +148,7 @@ func Install(filters []string, force, refreshResolvers, refreshFilters bool, pro
 // should be printed.
 func InstallAll(force, update, debug, refreshFilters bool) error {
 	InitLogging(debug)
+	defer ShutdownLogging()
 	Logger.Info("Installing filters...")
 	if !hasGit() {
 		Logger.Warn(gitNotInstalledWarning)
@@ -260,8 +262,10 @@ func Run(profileName string, debug bool) error {
 	// Get the context
 	context, err := prepareRunContext(profileName, debug, false)
 	if err != nil {
+		ShutdownLogging()
 		return burrito.PassError(err)
 	}
+	defer ShutdownLogging()
 	// Lock the session
 	unlockSession, sessionLockErr := acquireSessionLock(context.DotRegolithPath)
 	if sessionLockErr != nil {
@@ -284,8 +288,10 @@ func Watch(profileName string, debug bool) error {
 	// Get the context
 	context, err := prepareRunContext(profileName, debug, false)
 	if err != nil {
+		ShutdownLogging()
 		return burrito.PassError(err)
 	}
+	defer ShutdownLogging()
 	// Lock the session
 	unlockSession, sessionLockErr := acquireSessionLock(context.DotRegolithPath)
 	if sessionLockErr != nil {
@@ -331,6 +337,7 @@ func Watch(profileName string, debug bool) error {
 // properties of the filter are passed via commandline.
 func ApplyFilter(filterName string, filterArgs []string, debug bool) error {
 	InitLogging(debug)
+	defer ShutdownLogging()
 	// Load the Config and the profile
 	configJson, err := LoadConfigAsMap()
 	if err != nil {
@@ -422,6 +429,7 @@ func ApplyFilter(filterName string, filterArgs []string, debug bool) error {
 // should be printed.
 func Init(debug, force bool) error {
 	InitLogging(debug)
+	defer ShutdownLogging()
 	Logger.Info("Initializing Regolith project...")
 
 	wd, err := os.Getwd()
@@ -583,6 +591,7 @@ func CleanFilterCache() error {
 // should be printed.
 func Clean(debug, userCache, filterCache bool) error {
 	InitLogging(debug)
+	defer ShutdownLogging()
 	if userCache {
 		return CleanUserCache()
 	} else if filterCache {
@@ -598,6 +607,7 @@ func Clean(debug, userCache, filterCache bool) error {
 // should be printed.
 func UpdateResolvers(debug bool) error {
 	InitLogging(debug)
+	defer ShutdownLogging()
 	_, _, err := DownloadResolverMaps(true)
 	return err
 }
@@ -792,6 +802,7 @@ func manageUserConfigDelete(debug bool, index int, key string) error {
 //     or 2. The length determines the action of the command.
 func ManageConfig(debug, full, delete, append bool, index int, args []string) error {
 	InitLogging(debug)
+	defer ShutdownLogging()
 
 	var err error
 	// Based on number of arguments, determine what to do

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -394,7 +394,7 @@ func ApplyFilter(filterName string, filterArgs []string, debug bool) error {
 		return burrito.WrapErrorf(err, filterRunnerCheckError, filterName)
 	}
 	// Setup tmp directory
-	err = SetupTmpFiles(*config, dotRegolithPath)
+	err = SetupTmpFiles(runContext)
 	if err != nil {
 		return burrito.WrapErrorf(err, setupTmpFilesError, dotRegolithPath)
 	}

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -377,10 +377,9 @@ func ApplyFilter(filterName string, filterArgs []string, debug bool) error {
 
 	// Create the filter
 	runConfiguration := map[string]interface{}{
-		"filter":    filterName,
 		"arguments": filterArgs,
 	}
-	filterRunner, err := filterDefinition.CreateFilterRunner(runConfiguration)
+	filterRunner, err := filterDefinition.CreateFilterRunner(runConfiguration, filterName)
 	if err != nil {
 		return burrito.WrapErrorf(err, createFilterRunnerError, filterName)
 	}

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -291,12 +291,7 @@ func (f *RemoteFilter) subfilterCollection(dotRegolithPath string) (*FilterColle
 			return nil, extraFilterJsonErrorInfo(
 				path, burrito.WrapErrorf(err, jsonPathParseError, jsonPath))
 		}
-		// Remote filters don't have the "filter" key but this would break the
-		// code as it's required by local filters. Adding it here to make the
-		// code work.
-		// TODO - this is a hack, fix it!
-		filter["filter"] = filterId
-		filterRunner, err := filterInstaller.CreateFilterRunner(filter)
+		filterRunner, err := filterInstaller.CreateFilterRunner(filter, filterId)
 		if err != nil {
 			// TODO - better filterName?
 			filterName := fmt.Sprintf("%v filter from %s.", nth(i), path)

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -1,7 +1,6 @@
 package regolith
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -262,16 +261,9 @@ func RunProfileImpl(context RunContext) (bool, error) {
 func (f *RemoteFilter) subfilterCollection(dotRegolithPath string) (*FilterCollection, error) {
 	path := filepath.Join(f.GetDownloadPath(dotRegolithPath), "filter.json")
 	result := &FilterCollection{Filters: []FilterRunner{}}
-	file, err := os.ReadFile(path)
-
+	filterCollection, err := loadFilterConfig(path)
 	if err != nil {
-		return nil, burrito.WrappedErrorf(readFilterJsonError, path)
-	}
-
-	var filterCollection map[string]interface{}
-	err = json.Unmarshal(file, &filterCollection)
-	if err != nil {
-		return nil, burrito.WrapErrorf(err, jsonUnmarshalError, path)
+		return nil, burrito.WrapErrorf(err, readFilterJsonError, path)
 	}
 	// Filters
 	filtersObj, ok := filterCollection["filters"]

--- a/regolith/watcher.go
+++ b/regolith/watcher.go
@@ -133,6 +133,7 @@ func (d *DirWatcher) start() {
 	}
 }
 
-func isInDir(path string, root string) bool {
-	return strings.HasPrefix(path, filepath.Clean(root))
+func isInDir(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && !strings.HasPrefix(rel, "..")
 }

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Bedrock-OSS/regolith/regolith"
@@ -193,5 +194,26 @@ func TestInstallAll(t *testing.T) {
 		// TEST EVALUATION
 		t.Log("Evaluating the test results...")
 		comparePaths(expectedResultPath, ".", t)
+	}
+}
+
+// TestNestedRemoteFilter verifies that running a project with a remote filter
+// referencing another remote filter fails as expected.
+func TestNestedRemoteFilter(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	t.Log("Clearing the testing directory...")
+	tmpDir := prepareTestDirectory("TestNestedRemoteFilter", t)
+
+	t.Log("Copying the project files into the testing directory...")
+	copyFilesOrFatal(doubleRemoteProjectPath, tmpDir, t)
+	os.Chdir(tmpDir)
+
+	t.Log("Testing the 'regolith install-all' command (should fail)...")
+	err := regolith.InstallAll(false, false, true, false)
+	if err == nil {
+		t.Fatal("Expected 'regolith install-all' to fail, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), "version") {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/test/revertible_fs_operations_test.go
+++ b/test/revertible_fs_operations_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Bedrock-OSS/regolith/regolith"
+)
+
+func TestRevertibleDeleteDirRollback(t *testing.T) {
+	tmpDir := t.TempDir()
+	backupDir := filepath.Join(tmpDir, "backup")
+
+	// create directory structure to delete
+	dir := filepath.Join(tmpDir, "dir")
+	err := os.MkdirAll(filepath.Join(dir, "sub"), 0755)
+	if err != nil {
+		t.Fatalf("failed to create test dir: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(dir, "sub", "file.txt"), []byte("hello"), 0644)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	ops, err := regolith.NewRevertibleFsOperations(backupDir)
+	if err != nil {
+		t.Fatalf("failed to init revertible ops: %v", err)
+	}
+
+	if err := ops.Delete(dir); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("directory still exists or stat error: %v", err)
+	}
+
+	if err := ops.Undo(); err != nil {
+		t.Fatalf("undo failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sub", "file.txt")); err != nil {
+		t.Fatalf("directory not restored: %v", err)
+	}
+
+	if err := ops.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+}


### PR DESCRIPTION
This PR
1. Introduces new experiment `symlink_export`, that creates symlinks between export target and tmp folder
2. Refactors a lot of IO operations
3. Improves watch mode to check for interruptions after each subfilter of a remote filter
4. Replaces some usages of slices with maps for quick access
5. Reduced allocations
6. Refactors a lot of various small places in the codebase