### PR TITLE
Update 1.6.1

### DIFF
--- a/regolith/config.go
+++ b/regolith/config.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const latestCompatibleVersion = "1.4.0"
+const latestCompatibleVersion = "1.6.0"
 
 const StandardLibraryUrl = "github.com/Bedrock-OSS/regolith-filters"
 const ConfigFilePath = "config.json"

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -26,7 +26,7 @@ func GetExportPaths(
 	if semver.Compare(vFormatVersion, "v1.4.0") < 0 {
 		bpPath, rpPath, err = getExportPathsV1_2_0(
 			exportTarget, bpName, rpName)
-	} else if semver.Compare(vFormatVersion, "v1.4.0") == 0 {
+	} else if semver.Compare(vFormatVersion, "v1.6.0") <= 0 {
 		bpPath, rpPath, err = getExportPathsV1_4_0(
 			exportTarget, bpName, rpName)
 	} else {

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -1,8 +1,10 @@
 package regolith
 
 import (
-	"github.com/Bedrock-OSS/go-burrito/burrito"
+	"fmt"
 	"slices"
+
+	"github.com/Bedrock-OSS/go-burrito/burrito"
 )
 
 type FilterDefinition struct {
@@ -107,7 +109,13 @@ func filterFromObject(obj map[string]any, id string) (*Filter, error) {
 		case []any:
 			s := make([]string, len(arguments))
 			for i, v := range arguments {
-				s[i] = v.(string)
+				s[i], ok = v.(string)
+				if !ok {
+					return nil, burrito.WrappedErrorf(
+						jsonPropertyTypeError,
+						fmt.Sprintf("arguments->%d", i),
+						"string")
+				}
 			}
 			filter.Arguments = s
 		case []string:


### PR DESCRIPTION
**Bug Fixes:**
- When `filters->[filter]->arguments` is not a list of strings, Regolith prints an error instead of crashing.
- Fixed crashes when the `formatVersion` of the config.json file is set to 1.6.0.