### PR TITLE
Add extraArgs property on filter runners

### DIFF
--- a/main.go
+++ b/main.go
@@ -288,10 +288,12 @@ func main() {
 		Long:  regolithRunDesc,
 		Run: func(cmd *cobra.Command, args []string) {
 			var profile string
+			var extraFilterArgs []string
 			if len(args) != 0 {
 				profile = args[0]
+				extraFilterArgs = args[1:]
 			}
-			err = regolith.Run(profile, burrito.PrintStackTrace)
+			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace)
 		},
 	}
 	subcommands = append(subcommands, cmdRun)
@@ -303,10 +305,12 @@ func main() {
 		Long:  regolithWatchDesc,
 		Run: func(cmd *cobra.Command, args []string) {
 			var profile string
+			var extraFilterArgs []string
 			if len(args) != 0 {
 				profile = args[0]
+				extraFilterArgs = args[1:]
 			}
-			err = regolith.Watch(profile, burrito.PrintStackTrace)
+			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace)
 		},
 	}
 	subcommands = append(subcommands, cmdWatch)

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -261,4 +261,8 @@ const (
 
 	updatedFilesDumpError = "Failed to update the list of the files edited by Regolith." +
 		"This may cause the next run to fail."
+
+	invalidArgumentModeError = "The extraArgs property of a filter is invalid:\n" +
+		"Current value: %q\n" +
+		"Valid values are: %s"
 )

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -262,7 +262,7 @@ const (
 	updatedFilesDumpError = "Failed to update the list of the files edited by Regolith." +
 		"This may cause the next run to fail."
 
-	invalidArgumentModeError = "The extraArgs property of a filter is invalid:\n" +
+	invalidArgumentModeError = "The extraArguments property of a filter is invalid:\n" +
 		"Current value: %q\n" +
 		"Valid values are: %s"
 )

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -12,12 +12,13 @@ type FilterDefinition struct {
 }
 
 type Filter struct {
-	Id          string         `json:"filter,omitempty"`
-	Description string         `json:"name,omitempty"`
-	Disabled    bool           `json:"disabled,omitempty"`
-	Arguments   []string       `json:"arguments,omitempty"`
-	Settings    map[string]any `json:"settings,omitempty"`
-	When        string         `json:"when,omitempty"`
+	Id                 string         `json:"filter,omitempty"`
+	Description        string         `json:"name,omitempty"`
+	Disabled           bool           `json:"disabled,omitempty"`
+	Arguments          []string       `json:"arguments,omitempty"`
+	Settings           map[string]any `json:"settings,omitempty"`
+	When               string         `json:"when,omitempty"`
+	ExtraArgumentsMode string         `json:"extraArgs,omitempty"`
 }
 
 type RunContext struct {
@@ -28,6 +29,7 @@ type RunContext struct {
 	Parent           *RunContext
 	DotRegolithPath  string
 	Settings         map[string]any
+	ExtraArguments   []string
 
 	// interruption is a channel used to receive notifications about changes
 	// in the source files, in order to trigger a restart of the program in
@@ -154,6 +156,17 @@ func filterFromObject(obj map[string]any, id string) (*Filter, error) {
 		id = parsedId
 	}
 	filter.Id = id
+
+	// extraArgs mode
+	extraArgs, ok := obj["extraArgs"]
+	if ok {
+		extraArgs, ok := extraArgs.(string)
+		if !ok {
+			return nil, burrito.WrappedErrorf(jsonPropertyTypeError, "extraArgs", "string")
+		}
+		filter.ExtraArgumentsMode = extraArgs
+	}
+
 	return filter, nil
 }
 
@@ -190,6 +203,10 @@ type FilterRunner interface {
 	// IsUsingDataExport returns whether the filter wants its data to be
 	// exported back to the data folder after running the profile.
 	IsUsingDataExport(dotRegolithPath string, ctx RunContext) (bool, error)
+
+	// AddExtraArguments adds additional arguments to the filter according to
+	// the method provided in the filter runner settings
+	AddExtraArguments(extraArgs []string) error
 }
 
 func (f *Filter) CopyArguments(parent *RemoteFilter) {
@@ -232,6 +249,22 @@ func (f *Filter) IsDisabled(ctx RunContext) (bool, error) {
 
 func (f *Filter) IsUsingDataExport(_ string, _ RunContext) (bool, error) {
 	return false, nil
+}
+
+func (f *Filter) AddExtraArguments(extraArgs []string) error {
+	switch f.ExtraArgumentsMode {
+	case "", "ignore":
+	case "override":
+		f.Arguments = extraArgs
+	case "append":
+		f.Arguments = append(f.Arguments, extraArgs...)
+	default:
+		return burrito.WrappedErrorf(
+			invalidArgumentModeError,
+			// current value; valid values
+			f.ExtraArgumentsMode, "ignore, override, append")
+	}
+	return nil
 }
 
 type filterInstallerFactory struct {

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -18,7 +18,7 @@ type Filter struct {
 	Arguments          []string       `json:"arguments,omitempty"`
 	Settings           map[string]any `json:"settings,omitempty"`
 	When               string         `json:"when,omitempty"`
-	ExtraArgumentsMode string         `json:"extraArgs,omitempty"`
+	ExtraArgumentsMode string         `json:"extraArguments,omitempty"`
 }
 
 type RunContext struct {
@@ -157,14 +157,14 @@ func filterFromObject(obj map[string]any, id string) (*Filter, error) {
 	}
 	filter.Id = id
 
-	// extraArgs mode
-	extraArgs, ok := obj["extraArgs"]
+	// extraArguments mode
+	extraArguments, ok := obj["extraArguments"]
 	if ok {
-		extraArgs, ok := extraArgs.(string)
+		extraArguments, ok := extraArguments.(string)
 		if !ok {
-			return nil, burrito.WrappedErrorf(jsonPropertyTypeError, "extraArgs", "string")
+			return nil, burrito.WrappedErrorf(jsonPropertyTypeError, "extraArguments", "string")
 		}
-		filter.ExtraArgumentsMode = extraArgs
+		filter.ExtraArgumentsMode = extraArguments
 	}
 
 	return filter, nil
@@ -206,7 +206,7 @@ type FilterRunner interface {
 
 	// AddExtraArguments adds additional arguments to the filter according to
 	// the method provided in the filter runner settings
-	AddExtraArguments(extraArgs []string) error
+	AddExtraArguments(extraArguments []string) error
 }
 
 func (f *Filter) CopyArguments(parent *RemoteFilter) {
@@ -251,13 +251,13 @@ func (f *Filter) IsUsingDataExport(_ string, _ RunContext) (bool, error) {
 	return false, nil
 }
 
-func (f *Filter) AddExtraArguments(extraArgs []string) error {
+func (f *Filter) AddExtraArguments(extraArguments []string) error {
 	switch f.ExtraArgumentsMode {
 	case "", "ignore":
 	case "override":
-		f.Arguments = extraArgs
+		f.Arguments = extraArguments
 	case "append":
-		f.Arguments = append(f.Arguments, extraArgs...)
+		f.Arguments = append(f.Arguments, extraArguments...)
 	default:
 		return burrito.WrappedErrorf(
 			invalidArgumentModeError,

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -211,7 +211,7 @@ func InstallAll(force, update, debug, refreshFilters bool) error {
 
 // prepareRunContext prepares the context for the "regolith run" and
 // "regolith watch" commands.
-func prepareRunContext(profileName string, debug bool) (*RunContext, error) {
+func prepareRunContext(profileName string, extraFilterArgs []string, debug bool) (*RunContext, error) {
 	InitLogging(debug)
 	if profileName == "" {
 		profileName = "default"
@@ -254,14 +254,15 @@ func prepareRunContext(profileName string, debug bool) (*RunContext, error) {
 		Profile:          profileName,
 		DotRegolithPath:  dotRegolithPath,
 		Settings:         map[string]any{},
+		ExtraArguments:   extraFilterArgs,
 	}, nil
 }
 
 // Run handles the "regolith run" command. It runs selected profile and exports
 // created resource pack and behavior pack to the target destination.
-func Run(profileName string, debug bool) error {
+func Run(profileName string, extraFilterArgs []string, debug bool) error {
 	// Get the context
-	context, err := prepareRunContext(profileName, debug)
+	context, err := prepareRunContext(profileName, extraFilterArgs, debug)
 	defer ShutdownLogging()
 	if err != nil {
 		return burrito.PassError(err)
@@ -284,9 +285,9 @@ func Run(profileName string, debug bool) error {
 // Watch handles the "regolith watch" command. It watches the project
 // directories, and it runs selected profile and exports created resource pack
 // and behavior pack to the target destination when the project changes.
-func Watch(profileName string, debug bool) error {
+func Watch(profileName string, extraFilterArgs []string, debug bool) error {
 	// Get the context
-	context, err := prepareRunContext(profileName, debug)
+	context, err := prepareRunContext(profileName, extraFilterArgs, debug)
 	defer ShutdownLogging()
 	if err != nil {
 		return burrito.PassError(err)

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -287,6 +287,12 @@ func RunProfileImpl(context RunContext) (bool, error) {
 		if filter.GetId() != "" {
 			Logger.Infof("Running filter %s", filter.GetId())
 		}
+
+		err = filter.AddExtraArguments(context.ExtraArguments)
+		if err != nil {
+			return false, burrito.WrapErrorf(err, filterRunnerRunError, filter.GetId())
+		}
+
 		// Run the filter in watch mode
 		start := time.Now()
 		interrupted, err := filter.Run(context)

--- a/test/conditional_filters_test.go
+++ b/test/conditional_filters_test.go
@@ -29,7 +29,7 @@ func TestConditionalFilter(t *testing.T) {
 
 	// THE TEST
 	t.Log("Running Regolith with a conditional filter...")
-	if err := regolith.Run("default", true); err != nil {
+	if err := regolith.Run("default", []string{}, true); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/custom_pack_name_test.go
+++ b/test/custom_pack_name_test.go
@@ -30,7 +30,7 @@ func TestCustomPackName(t *testing.T) {
 
 	// THE TEST
 	t.Log("Running Regolith with a conditional filter...")
-	if err := regolith.Run("default", true); err != nil {
+	if err := regolith.Run("default", []string{}, true); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/development_export_windows_test.go
+++ b/test/development_export_windows_test.go
@@ -103,7 +103,7 @@ func _testCustomDevelopmentExportLocation(
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run(profileToRun, true)
+	err = regolith.Run(profileToRun, []string{}, true)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/file_protection_test.go
+++ b/test/file_protection_test.go
@@ -34,18 +34,18 @@ func TestSwitchingExportTargets(t *testing.T) {
 	// Run Regolith with targets: A, B, A
 	t.Log("Testing the 'regolith run' with changing export targets...")
 	t.Log("Running Regolith with target A...")
-	err := regolith.Run("exact_export_A", true)
+	err := regolith.Run("exact_export_A", []string{}, true)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on first attempt to export to A:", err)
 	}
 	t.Log("Running Regolith with target B...")
-	err = regolith.Run("exact_export_B", true)
+	err = regolith.Run("exact_export_B", []string{}, true)
 	if err != nil {
 		t.Fatal("Unable RunProfile failed on attempt to export to B:", err)
 	}
 	t.Log("Running Regolith with target A (2nd time)...")
-	err = regolith.Run("exact_export_A", true)
+	err = regolith.Run("exact_export_A", []string{}, true)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on second attempt to export to A:", err)
@@ -78,7 +78,7 @@ func TestTriggerFileProtection(t *testing.T) {
 	// 1. Run Regolith (export to A)
 	t.Log("Testing the 'regolith run' with file protection...")
 	t.Log("Running Regolith...")
-	err := regolith.Run("exact_export_A", true)
+	err := regolith.Run("exact_export_A", []string{}, true)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on first attempt to export to A:", err)
@@ -94,7 +94,7 @@ func TestTriggerFileProtection(t *testing.T) {
 
 	// 3. Run Regolith (export to A), expect failure.
 	t.Log("Running Regolith (this should be stopped by file protection system)...")
-	err = regolith.Run("exact_export_A", true)
+	err = regolith.Run("exact_export_A", []string{}, true)
 	if err == nil {
 		t.Fatal("Expected RunProfile to fail on second attempt to export to A")
 	}

--- a/test/filter_async_test.go
+++ b/test/filter_async_test.go
@@ -30,7 +30,7 @@ func TestAsyncFilter(t *testing.T) {
 	t.Log("Running Regolith with a conditional filter...")
 
 	start := time.Now()
-	if err := regolith.Run("default", true); err != nil {
+	if err := regolith.Run("default", []string{}, true); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	duration := time.Since(start)

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -44,7 +44,7 @@ func TestRegolithRunMissingRp(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	// THE TEST
-	err := regolith.Run("dev", true)
+	err := regolith.Run("dev", []string{}, true)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}
@@ -71,7 +71,7 @@ func TestLocalRequirementsInstallAndRun(t *testing.T) {
 		t.Fatal("'regolith install-all' failed", err.Error())
 	}
 	t.Log("Testing the 'regolith run' command...")
-	if err := regolith.Run("dev", true); err != nil {
+	if err := regolith.Run("dev", []string{}, true); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 }
@@ -95,7 +95,7 @@ func TestExeFilterRun(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	if err := regolith.Run("dev", true); err != nil {
+	if err := regolith.Run("dev", []string{}, true); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	// TEST EVALUATION
@@ -125,7 +125,7 @@ func TestProfileFilterRun(t *testing.T) {
 	// THE TEST
 	// Invalid profile (shoud fail)
 	t.Log("Running invalid profile filter with circular dependencies (this should fail).")
-	err := regolith.Run("invalid_circular_profile_1", true)
+	err := regolith.Run("invalid_circular_profile_1", []string{}, true)
 	if err == nil {
 		t.Fatal("'regolith run' didn't return an error after running" +
 			" a circular profile filter.")
@@ -134,7 +134,7 @@ func TestProfileFilterRun(t *testing.T) {
 	}
 	// Valid profile (should succeed)
 	t.Log("Running valid profile filter.")
-	err = regolith.Run("correct_nested_profile", true)
+	err = regolith.Run("correct_nested_profile", []string{}, true)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -38,7 +38,7 @@ func TestInstallAllAndRun(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("dev", true)
+	err = regolith.Run("dev", []string{}, true)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}
@@ -78,7 +78,7 @@ func TestDataModifyRemoteFilter(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("default", true)
+	err = regolith.Run("default", []string{}, true)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/size_time_check_optimization_method_test.go
+++ b/test/size_time_check_optimization_method_test.go
@@ -51,7 +51,7 @@ func TestSizeTimeCheckOptimizationCorectness(t *testing.T) {
 	// Run the project
 	t.Log("Running Regolith...")
 
-	if err := regolith.Run("default", true); err != nil {
+	if err := regolith.Run("default", []string{}, true); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	// TEST EVALUATION
@@ -94,7 +94,7 @@ func TestSizeTimeCheckOptimizationSpeed(t *testing.T) {
 
 		// Start the timer
 		start := time.Now()
-		if err := regolith.Run("default", true); err != nil {
+		if err := regolith.Run("default", []string{}, true); err != nil {
 			t.Fatal("'regolith run' failed:", err.Error())
 		}
 		// Stop the timer


### PR DESCRIPTION
Added the `extraArguments` property to filter runners. It is used to pass arguments to filters via the run and watch subcommands.
e.g. `regolith run <profile> -- [filter_args...]`
```
[
    {
        "filter": "example_filter",
        "extraArguments": "ignore" // Default option
    },
    {
        "filter": "example_filter",
        "extraArguments": "override"
    },
    {
        "filter": "example_filter",
        "extraArguments": "append"
    }
]
```