### PR TITLE
Add 'nested' flag to evaluation scope

### DIFF
--- a/regolith/evaluator.go
+++ b/regolith/evaluator.go
@@ -61,6 +61,7 @@ func prepareScope(ctx RunContext) map[string]any {
 		"settings":       ctx.Settings,
 		"project":        projectData,
 		"mode":           mode,
+		"nested":         ctx.Parent != nil,
 		"initial":        ctx.Initial,
 	}
 }


### PR DESCRIPTION
Introduces a 'nested' boolean to the scope in prepareScope, indicating if the current context has a parent. This can be used to differentiate between nested and top-level evaluations.