### PR TITLE
User configuration setting - `tmp_dir`

### DIFF
--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -194,7 +194,7 @@ const (
 	// Error used on attempt to access user config property that is not known
 	// to Regolith.
 	invalidUserConfigPropertyError = "Invalid user configuration property:\n" +
-		"Property name: %s\n"
+		"Property name: %s"
 
 	// Error used when the getGlobalUserConfigPath function fails
 	getGlobalUserConfigPathError = "Failed to get global user_config.json path"
@@ -268,4 +268,6 @@ const (
 
 	loadEnvFileFromArgError = "Failed to the file with environment variables:\n" +
 		"File path: %s"
+
+	getAbsoluteWorkingDirectoryError = "Failed to get the absolute path of the working directory for filter execution."
 )

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -327,25 +327,29 @@ func exportProjectRpAndBp(profile Profile, rpPath, bpPath string, ctx RunContext
 		}
 	}
 	MeasureStart("Export - MoveOrCopy")
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(dotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	var wg sync.WaitGroup
 	packsData := []struct {
-		packPath string
-		tmpPath  string
-		packType string
+		packPath     string
+		subpathInTmp string
+		packType     string
 	}{
-		{bpPath, "tmp/BP", "behavior"},
-		{rpPath, "tmp/RP", "resource"},
+		{bpPath, "BP", "behavior"},
+		{rpPath, "RP", "resource"},
 	}
 	errChan := make(chan error, len(packsData))
 	for _, packData := range packsData {
-		packPath, tmpPath, packType := packData.packPath, packData.tmpPath, packData.packType
+		packPath, subpathInTmp, packType := packData.packPath, packData.subpathInTmp, packData.packType
 		wg.Go(func() {
 			Logger.Infof("Exporting %s pack to \"%s\".", packType, packPath)
 			var e error
 			if IsExperimentEnabled(SizeTimeCheck) {
-				e = SyncDirectories(filepath.Join(dotRegolithPath, tmpPath), packPath, exportTarget.ReadOnly)
+				e = SyncDirectories(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly)
 			} else {
-				e = MoveOrCopy(filepath.Join(dotRegolithPath, tmpPath), packPath, exportTarget.ReadOnly, true)
+				e = MoveOrCopy(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly, true)
 			}
 			if e != nil {
 				errChan <- burrito.WrapErrorf(e, "Failed to export %s pack.", packType)
@@ -421,6 +425,10 @@ func exportProjectData(profile Profile, ctx RunContext) error {
 		return burrito.WrapErrorf(err, newRevertibleFsOperationsError, backupPath)
 	}
 	// Export data
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(dotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	for _, exportedFilterName := range exportedFilterNames {
 		// Clear export target
 		targetPath := filepath.Join(dataPath, exportedFilterName)
@@ -445,7 +453,7 @@ func exportProjectData(profile Profile, ctx RunContext) error {
 		} else {
 			return burrito.WrapErrorf(err, osStatErrorAny, targetPath)
 		}
-		sourcePath := filepath.Join(dotRegolithPath, "tmp/data", exportedFilterName)
+		sourcePath := filepath.Join(absWorkingDir, "data", exportedFilterName)
 		// If source path doesn't exist, skip
 		if _, err := os.Stat(sourcePath); os.IsNotExist(err) {
 			continue
@@ -516,10 +524,14 @@ func InplaceExportProject(
 		}
 	}
 	// Move files from tmp to RP, BP and data
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(dotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	moveFiles := [][2]string{
-		{filepath.Join(dotRegolithPath, "tmp/RP"), config.ResourceFolder},
-		{filepath.Join(dotRegolithPath, "tmp/BP"), config.BehaviorFolder},
-		{filepath.Join(dotRegolithPath, "tmp/data"), config.DataPath},
+		{filepath.Join(absWorkingDir, "RP"), config.ResourceFolder},
+		{filepath.Join(absWorkingDir, "BP"), config.BehaviorFolder},
+		{filepath.Join(absWorkingDir, "data"), config.DataPath},
 	}
 	for _, moveFile := range moveFiles {
 		source, target := moveFile[0], moveFile[1]

--- a/regolith/filter_deno.go
+++ b/regolith/filter_deno.go
@@ -35,7 +35,10 @@ func DenoFilterDefinitionFromObject(id string, obj map[string]any) (*DenoFilterD
 }
 
 func (f *DenoFilter) run(context RunContext) error {
-	// Run filter
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(context.DotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
 			"deno",
@@ -46,7 +49,7 @@ func (f *DenoFilter) run(context RunContext) error {
 				f.Arguments...,
 			),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {
@@ -62,7 +65,7 @@ func (f *DenoFilter) run(context RunContext) error {
 					f.Definition.Script,
 				string(jsonSettings)}, f.Arguments...),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {

--- a/regolith/filter_dotnet.go
+++ b/regolith/filter_dotnet.go
@@ -39,7 +39,10 @@ func (f *DotNetFilter) Run(context RunContext) (bool, error) {
 }
 
 func (f *DotNetFilter) run(context RunContext) error {
-	// Run the filter
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(context.DotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
 			"dotnet",
@@ -51,7 +54,7 @@ func (f *DotNetFilter) run(context RunContext) error {
 				f.Arguments...,
 			),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {
@@ -68,7 +71,7 @@ func (f *DotNetFilter) run(context RunContext) error {
 				f.Arguments...,
 			),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {

--- a/regolith/filter_exe.go
+++ b/regolith/filter_exe.go
@@ -75,19 +75,21 @@ func (f *ExeFilter) run(
 	settings map[string]any,
 	context RunContext,
 ) error {
-	var err error = nil
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(context.DotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	if len(settings) == 0 {
 		err = executeExeFile(f.Id,
 			f.Definition.Exe,
 			f.Arguments, context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath))
+			absWorkingDir)
 	} else {
 		jsonSettings, _ := json.Marshal(settings)
 		err = executeExeFile(f.Id,
 			f.Definition.Exe,
 			append([]string{string(jsonSettings)}, f.Arguments...),
-			context.AbsoluteLocation, GetAbsoluteWorkingDirectory(
-				context.DotRegolithPath))
+			context.AbsoluteLocation, absWorkingDir)
 	}
 	if err != nil {
 		return burrito.WrapErrorf(

--- a/regolith/filter_java.go
+++ b/regolith/filter_java.go
@@ -51,7 +51,10 @@ func (f *JavaFilter) Run(context RunContext) (bool, error) {
 }
 
 func (f *JavaFilter) run(context RunContext) error {
-	// Run the filter
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(context.DotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
 			"java",
@@ -63,7 +66,7 @@ func (f *JavaFilter) run(context RunContext) error {
 				f.Arguments...,
 			),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {
@@ -80,7 +83,7 @@ func (f *JavaFilter) run(context RunContext) error {
 				f.Arguments...,
 			),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {

--- a/regolith/filter_nim.go
+++ b/regolith/filter_nim.go
@@ -53,7 +53,10 @@ func NimFilterDefinitionFromObject(
 }
 
 func (f *NimFilter) run(context RunContext) error {
-	// Run filter
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(context.DotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
 			"nim",
@@ -63,7 +66,7 @@ func (f *NimFilter) run(context RunContext) error {
 				f.Arguments...,
 			),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {
@@ -80,7 +83,7 @@ func (f *NimFilter) run(context RunContext) error {
 				string(jsonSettings)},
 				f.Arguments...),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {

--- a/regolith/filter_nodejs.go
+++ b/regolith/filter_nodejs.go
@@ -51,7 +51,10 @@ func NodeJSFilterDefinitionFromObject(id string, obj map[string]any) (*NodeJSFil
 }
 
 func (f *NodeJSFilter) run(context RunContext) error {
-	// Run filter
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(context.DotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
 			"node",
@@ -61,7 +64,7 @@ func (f *NodeJSFilter) run(context RunContext) error {
 				f.Arguments...,
 			),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {
@@ -76,7 +79,7 @@ func (f *NodeJSFilter) run(context RunContext) error {
 					f.Definition.Script,
 				string(jsonSettings)}, f.Arguments...),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			absWorkingDir,
 			ShortFilterName(f.Id),
 		)
 		if err != nil {

--- a/regolith/filter_python.go
+++ b/regolith/filter_python.go
@@ -54,7 +54,10 @@ func PythonFilterDefinitionFromObject(id string, obj map[string]any) (*PythonFil
 }
 
 func (f *PythonFilter) run(context RunContext) error {
-	// Run filter
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(context.DotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	pythonCommand, err := findPython()
 	if err != nil {
 		return burrito.PassError(err)
@@ -94,7 +97,7 @@ func (f *PythonFilter) run(context RunContext) error {
 	}
 	err = RunSubProcess(
 		pythonCommand, args, context.AbsoluteLocation,
-		GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+		absWorkingDir,
 		ShortFilterName(f.Id))
 	if err != nil {
 		return burrito.WrapError(err, "Failed to run Python script.")

--- a/regolith/filter_shell.go
+++ b/regolith/filter_shell.go
@@ -81,19 +81,22 @@ func (f *ShellFilter) run(
 	settings map[string]any,
 	context RunContext,
 ) error {
-	var err error = nil
+	absWorkingDir, err := GetAbsoluteWorkingDirectory(context.DotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
 	if len(settings) == 0 {
 		err = executeCommand(f.Id,
 			f.Definition.Command,
 			f.Arguments, context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath))
+			absWorkingDir)
 	} else {
 		jsonSettings, _ := json.Marshal(settings)
 		err = executeCommand(f.Id,
 			f.Definition.Command,
 			append([]string{string(jsonSettings)}, f.Arguments...),
 			context.AbsoluteLocation,
-			GetAbsoluteWorkingDirectory(context.DotRegolithPath))
+			absWorkingDir)
 	}
 	if err != nil {
 		return burrito.WrapError(err, "Failed to run shell command.")

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -757,6 +757,11 @@ func manageUserConfigEdit(index int, key, value string) error {
 				resolversSet[resolver] = struct{}{}
 			}
 		}
+	case "tmp_dir":
+		if index != -1 {
+			return burrito.WrappedError("Cannot use --index with non-array property.")
+		}
+		userConfig.TmpDir = &value
 	default:
 		return burrito.WrappedErrorf(invalidUserConfigPropertyError, key)
 	}
@@ -799,6 +804,11 @@ func manageUserConfigDelete(index int, key string) error {
 				userConfig.Resolvers[:index],
 				userConfig.Resolvers[index+1:]...)
 		}
+	case "tmp_dir":
+		if index != -1 {
+			return burrito.WrappedError("Cannot use --index with non-array property.")
+		}
+		userConfig.TmpDir = nil
 	default:
 		return burrito.WrappedErrorf(invalidUserConfigPropertyError, key)
 	}

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -121,9 +121,12 @@ func SetupTmpFiles(context RunContext) error {
 	start := time.Now()
 	useSizeTimeCheck := IsExperimentEnabled(SizeTimeCheck)
 	useSymlinkExport := IsExperimentEnabled(SymlinkExport)
-	tmpPath := filepath.Join(dotRegolithPath, "tmp")
-	bpTmpPath := filepath.Join(tmpPath, "BP")
-	rpTmpPath := filepath.Join(tmpPath, "RP")
+	absTmpPath, err := GetAbsoluteWorkingDirectory(dotRegolithPath)
+	if err != nil {
+		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
+	}
+	bpTmpPath := filepath.Join(absTmpPath, "BP")
+	rpTmpPath := filepath.Join(absTmpPath, "RP")
 
 	// Check if should create symlinks, if yes load bp and rp paths
 	var bpExportPath, rpExportPath string
@@ -165,17 +168,17 @@ func SetupTmpFiles(context RunContext) error {
 	// Clean the temporary directory
 	isRegularRun := !useSizeTimeCheck && !useSymlinkExport
 	if isRegularRun || shouldCreateSymlinks {
-		Logger.Debugf("Cleaning \"%s\"", tmpPath)
-		err := os.RemoveAll(tmpPath)
+		Logger.Debugf("Cleaning \"%s\"", absTmpPath)
+		err := os.RemoveAll(absTmpPath)
 		if err != nil {
-			return burrito.WrapErrorf(err, osRemoveError, tmpPath)
+			return burrito.WrapErrorf(err, osRemoveError, absTmpPath)
 		}
 	}
 
 	// Prepare temp path root
-	err := os.MkdirAll(tmpPath, 0755)
+	err = os.MkdirAll(absTmpPath, 0755)
 	if err != nil {
-		return burrito.WrapErrorf(err, osMkdirError, tmpPath)
+		return burrito.WrapErrorf(err, osMkdirError, absTmpPath)
 	}
 
 	// Create symlinks
@@ -199,22 +202,22 @@ func SetupTmpFiles(context RunContext) error {
 		}
 
 		// Create symlinks
-		if err := createDirLink(filepath.Join(tmpPath, "BP"), bpExportPath); err != nil {
-			return burrito.WrapErrorf(err, createDirLinkError, filepath.Join(tmpPath, "BP"), bpExportPath)
+		if err := createDirLink(filepath.Join(absTmpPath, "BP"), bpExportPath); err != nil {
+			return burrito.WrapErrorf(err, createDirLinkError, filepath.Join(absTmpPath, "BP"), bpExportPath)
 		}
-		if err := createDirLink(filepath.Join(tmpPath, "RP"), rpExportPath); err != nil {
-			return burrito.WrapErrorf(err, createDirLinkError, filepath.Join(tmpPath, "RP"), rpExportPath)
+		if err := createDirLink(filepath.Join(absTmpPath, "RP"), rpExportPath); err != nil {
+			return burrito.WrapErrorf(err, createDirLinkError, filepath.Join(absTmpPath, "RP"), rpExportPath)
 		}
 	}
 
 	// Copy the contents of the 'regolith' folder to '[dotRegolithPath]/tmp'
-	Logger.Debugf("Copying project files to \"%s\"", tmpPath)
+	Logger.Debugf("Copying project files to \"%s\"", absTmpPath)
 	// Avoid repetitive code of preparing ResourceFolder, BehaviorFolder
 	// and DataPath with a closure
 	setupTmpDirectory := func(
 		path, shortName, descriptiveName string,
 	) error {
-		p := filepath.Join(tmpPath, shortName)
+		p := filepath.Join(absTmpPath, shortName)
 		if path != "" {
 			stats, err := os.Stat(path)
 			if err != nil {

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -42,6 +42,11 @@ type UserConfig struct {
 
 	// FilterCacheUpdateCooldown is a cooldown duration, to not update resolver cache too often.
 	FilterCacheUpdateCooldown *string `json:"filter_cache_update_cooldown,omitempty"`
+
+	// TmpDir is optional path for setting where regolith should create the tmp directory
+	// for running filters. When not set, the tmp directory will be placed inside
+	// the project in .regolith directory.
+	TmpDir *string `json:"tmp_dir,omitempty"`
 }
 
 func NewUserConfig() *UserConfig {
@@ -51,6 +56,7 @@ func NewUserConfig() *UserConfig {
 		Resolvers:                   []string{},
 		ResolverCacheUpdateCooldown: nil,
 		FilterCacheUpdateCooldown:   nil,
+		TmpDir:                      nil,
 	}
 }
 
@@ -63,6 +69,8 @@ func (u *UserConfig) String() string {
 	extra, _ = u.stringPropertyValue("resolver_cache_update_cooldown")
 	result += "\n" + extra
 	extra, _ = u.stringPropertyValue("filter_cache_update_cooldown")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("tmp_dir")
 	result += "\n" + extra
 	return result
 }
@@ -104,6 +112,12 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 			value = fmt.Sprintf("%v", *u.FilterCacheUpdateCooldown)
 		}
 		return fmt.Sprintf("filter_cache_update_cooldown: %v", value), nil
+	case "tmp_dir":
+		value := "null"
+		if u.TmpDir != nil {
+			value = fmt.Sprintf("%v", *u.TmpDir)
+		}
+		return fmt.Sprintf("tmp_dir: %v", value), nil
 	}
 	return "", burrito.WrapErrorf(nil, invalidUserConfigPropertyError, name)
 }
@@ -125,6 +139,10 @@ func (u *UserConfig) fillDefaults() {
 	if u.FilterCacheUpdateCooldown == nil {
 		u.FilterCacheUpdateCooldown = new(string)
 		*u.FilterCacheUpdateCooldown = "5m"
+	}
+	if u.TmpDir == nil {
+		u.TmpDir = new(string)
+		*u.TmpDir = ""
 	}
 	// Make sure resolvers is not nil and append the default resolver
 	if u.Resolvers == nil {

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -103,10 +103,29 @@ func NotImplementedError(text string) error {
 	return burrito.WrappedError(text)
 }
 
-// GetAbsoluteWorkingDirectory returns an absolute path to [dotRegolithPath]/tmp
-func GetAbsoluteWorkingDirectory(dotRegolithPath string) string {
-	absoluteWorkingDir, _ := filepath.Abs(filepath.Join(dotRegolithPath, "tmp"))
-	return absoluteWorkingDir
+// GetWorkingDirectory returns the working directory for Regolith (the tmp path).
+// [dotRegolithPath]/tmp by default or a path from user config, with
+// /tmp appended to it. The returned path is not absolute.
+func GetAbsoluteWorkingDirectory(dotRegolithPath string) (string, error) {
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return "", burrito.WrapError(err, getUserConfigError)
+	}
+	if userConfig.TmpDir == nil {
+		// Should never happen - getComvinedUserConfig() fills the defaults
+		return "", burrito.WrappedError("tmp_dir is null in user config")
+	}
+	tmpDir := filepath.Join(*userConfig.TmpDir, "tmp")
+	if !filepath.IsAbs(tmpDir) {
+		tmpDir = filepath.Join(dotRegolithPath, tmpDir)
+		absTmpDir, err := filepath.Abs(tmpDir)
+		if err != nil {
+			return "", burrito.WrapErrorf(err, filepathAbsError, tmpDir)
+		}
+		return absTmpDir, nil
+	}
+	// else IsAbs == true: clean and return
+	return filepath.Clean(tmpDir), nil
 }
 
 // CreateEnvironmentVariables creates an array of environment variables including custom ones

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -124,8 +124,22 @@ func GetAbsoluteWorkingDirectory(dotRegolithPath string) (string, error) {
 		}
 		return absTmpDir, nil
 	}
-	// else IsAbs == true: clean and return
-	return filepath.Clean(tmpDir), nil
+	// Path is NOT absolute, this means we're using userConfig.TmpDir,
+	// instead of using the 'tmp' folder we use a hash from the Regolith's
+	// working directory to avoid collisions when multiple instances of
+	// Regolith are running.
+
+	// Get the md5 of the current working directory
+	projectDir, err := os.Getwd()
+	if err != nil {
+		return "", burrito.WrapErrorf(err, osGetwdError)
+	}
+	hash := md5.New()
+	hash.Write([]byte(projectDir))
+	hashInBytes := hash.Sum(nil)
+	projectPathHash := hex.EncodeToString(hashInBytes)
+
+	return filepath.Clean(filepath.Join(*userConfig.TmpDir, projectPathHash)), nil
 }
 
 // CreateEnvironmentVariables creates an array of environment variables including custom ones


### PR DESCRIPTION
This PR adds a new feature to Regolith that allows you to overwrite the location of `tmp` folder. It is useful when you combine it with a RAM drive like [ImDisk](https://github.com/LTRData/ImDisk?tab=readme-ov-file). This approach speeds up filters which are the main bottleneck in Regolith execution. In my very non-scientific testing on a random project using ImDisk I got 25% faster execution time.

The path specified in user config is not directly the path that Regolith uses as root of RP, BP and data. A `tmp` subfolder is always added to prevent accidental file deletion, since Regolith treats the content of working directory as safe to delete. There is still technically a small risk of accidental file deletion, if someone uses a folder named `tmp` for something important and they decide to set their `tmp_dir` setting to point at the parent directory of that important `tmp` folder, but I think it's not a big issue.

---
The ImDisk download site looks really shady. I don't remember how I got the app originally because I downloaded it like a year ago. Hopefully I'm not sending a link to some malware 😘.

I think they develop the Arsenal Image Mounter now and ImDisk is not supported anymore.