### PR TITLE
Add Bun filter runner support

### DIFF
--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -303,6 +303,12 @@ var filterInstallerFactories = map[string]filterInstallerFactory{
 		},
 		name: "NodeJs",
 	},
+	"bun": {
+		constructor: func(id string, obj map[string]any) (FilterInstaller, error) {
+			return BunFilterDefinitionFromObject(id, obj)
+		},
+		name: "Bun",
+	},
 	"python": {
 		constructor: func(id string, obj map[string]any) (FilterInstaller, error) {
 			return PythonFilterDefinitionFromObject(id, obj)

--- a/regolith/filter_bun.go
+++ b/regolith/filter_bun.go
@@ -107,9 +107,23 @@ func (f *BunFilterDefinition) Check(context RunContext) error {
 	return nil
 }
 
-func (f *BunFilterDefinition) InstallDependencies(
-	parent *RemoteFilterDefinition, dotRegolithPath string,
-) error {
+func (f *BunFilterDefinition) InstallDependencies(parent *RemoteFilterDefinition, dotRegolithPath string) error {
+	installLocation := ""
+	// Install dependencies
+	if parent != nil {
+		installLocation = parent.GetDownloadPath(dotRegolithPath)
+	}
+	Logger.Infof("Downloading dependencies for %s...", f.Id)
+	if hasPackageJson(installLocation) {
+		Logger.Info("Installing bun dependencies...")
+		err := RunSubProcess("bun", []string{"install", "--silent"}, installLocation, installLocation, ShortFilterName(f.Id))
+		if err != nil {
+			return burrito.WrapErrorf(
+				err, "Failed to run bun and install dependencies."+
+					"\nFilter name: %s", f.Id)
+		}
+	}
+	Logger.Infof("Dependencies for %s installed successfully", f.Id)
 	return nil
 }
 

--- a/regolith/filter_bun.go
+++ b/regolith/filter_bun.go
@@ -1,0 +1,118 @@
+package regolith
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Bedrock-OSS/go-burrito/burrito"
+)
+
+type BunFilterDefinition struct {
+	FilterDefinition
+	Script string `json:"script,omitempty"`
+}
+
+type BunFilter struct {
+	Filter
+	Definition BunFilterDefinition `json:"-"`
+}
+
+func BunFilterDefinitionFromObject(id string, obj map[string]any) (*BunFilterDefinition, error) {
+	filter := &BunFilterDefinition{FilterDefinition: *FilterDefinitionFromObject(id)}
+	scriptObj, ok := obj["script"]
+	if !ok {
+		return nil, burrito.WrappedErrorf(jsonPropertyMissingError, "script")
+	}
+	script, ok := scriptObj.(string)
+	if !ok {
+		return nil, burrito.WrappedErrorf(
+			jsonPropertyTypeError, "script", "string")
+	}
+	filter.Script = script
+	return filter, nil
+}
+
+func (f *BunFilter) run(context RunContext) error {
+	// Run filter
+	if len(f.Settings) == 0 {
+		err := RunSubProcess(
+			"bun",
+			append([]string{
+				"run",
+				context.AbsoluteLocation + string(os.PathSeparator) +
+					f.Definition.Script},
+				f.Arguments...,
+			),
+			context.AbsoluteLocation,
+			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			ShortFilterName(f.Id),
+		)
+		if err != nil {
+			return burrito.WrapError(err, runSubProcessError)
+		}
+	} else {
+		jsonSettings, _ := json.Marshal(f.Settings)
+		err := RunSubProcess(
+			"bun",
+			append([]string{
+				"run",
+				context.AbsoluteLocation + string(os.PathSeparator) +
+					f.Definition.Script,
+				string(jsonSettings)}, f.Arguments...),
+			context.AbsoluteLocation,
+			GetAbsoluteWorkingDirectory(context.DotRegolithPath),
+			ShortFilterName(f.Id),
+		)
+		if err != nil {
+			return burrito.WrapError(err, runSubProcessError)
+		}
+	}
+	return nil
+}
+
+func (f *BunFilter) Run(context RunContext) (bool, error) {
+	if err := f.run(context); err != nil {
+		return false, burrito.PassError(err)
+	}
+	return context.IsInterrupted(), nil
+}
+
+func (f *BunFilterDefinition) CreateFilterRunner(runConfiguration map[string]any, id string) (FilterRunner, error) {
+	basicFilter, err := filterFromObject(runConfiguration, id)
+	if err != nil {
+		return nil, burrito.WrapError(err, filterFromObjectError)
+	}
+	filter := &BunFilter{
+		Filter:     *basicFilter,
+		Definition: *f,
+	}
+	return filter, nil
+}
+
+func (f *BunFilterDefinition) Check(context RunContext) error {
+	_, err := exec.LookPath("bun")
+	if err != nil {
+		return burrito.WrapError(
+			err, "Bun not found, download and install it from"+
+				" https://bun.com/")
+	}
+	cmd, err := exec.Command("bun", "--version").Output()
+	if err != nil {
+		return burrito.WrapError(err, "Failed to check Bun version")
+	}
+	a := strings.TrimPrefix(strings.Trim(string(cmd), " \n\t"), "v")
+	Logger.Debugf("Found Bun version %s", a)
+	return nil
+}
+
+func (f *BunFilterDefinition) InstallDependencies(
+	parent *RemoteFilterDefinition, dotRegolithPath string,
+) error {
+	return nil
+}
+
+func (f *BunFilter) Check(context RunContext) error {
+	return f.Definition.Check(context)
+}


### PR DESCRIPTION
## Description
This PR introduces support for [**Bun**](https://bun.com/) as an execution runtime for filters, alongside the existing options. 

## Motivation and Context
Bun is gaining traction as a fast, all-in-one JavaScript/TypeScript toolkit. Allowing creators to write and execute their filters using Bun can significantly speed up execution times and improve the developer experience for those using it as their primary JS environment. 

## What changed
* **Added `regolith/filter_bun.go`**: Implemented the core definition and execution logic for the Bun filter type.
* **Modified `regolith/filter.go`**: Updated the filter handler to recognize and apply the new Bun filter definition.

## Testing & Environment
- [x] Successfully built the code locally.
- [x] Created and executed a test filter using Bun.
- [x] Verified that existing runtimes remain unaffected. 

**Tested on:**
* **OS:** Windows 11
* **Bun version:** 1.3.5