### PR TITLE
Runner paths user config

### DIFF
--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -337,6 +337,14 @@ var filterInstallerFactories = map[string]filterInstallerFactory{
 
 func FilterInstallerFromObject(id string, obj map[string]any) (FilterInstaller, error) {
 	runWith, _ := obj["runWith"].(string)
+	if runWith == "nodejs" {
+		userConfig, err := getCombinedUserConfig()
+		if err != nil {
+			return nil, burrito.WrapError(err, getUserConfigError)
+		}
+		// Defaults to "nodejs" (no change)
+		runWith = *userConfig.NodeRunnerOverride
+	}
 	if factory, ok := filterInstallerFactories[runWith]; ok {
 		filter, err := factory.constructor(id, obj)
 		if err != nil {

--- a/regolith/filter_bun.go
+++ b/regolith/filter_bun.go
@@ -39,10 +39,15 @@ func (f *BunFilter) run(context RunContext) error {
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	bunRunner := *userConfig.BunRunner
 	// Run filter
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
-			"bun",
+			bunRunner,
 			append([]string{
 				"run",
 				context.AbsoluteLocation + string(os.PathSeparator) +
@@ -59,7 +64,7 @@ func (f *BunFilter) run(context RunContext) error {
 	} else {
 		jsonSettings, _ := json.Marshal(f.Settings)
 		err := RunSubProcess(
-			"bun",
+			bunRunner,
 			append([]string{
 				"run",
 				context.AbsoluteLocation + string(os.PathSeparator) +
@@ -96,13 +101,18 @@ func (f *BunFilterDefinition) CreateFilterRunner(runConfiguration map[string]any
 }
 
 func (f *BunFilterDefinition) Check(context RunContext) error {
-	_, err := exec.LookPath("bun")
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	bunRunner := *userConfig.BunRunner
+	_, err = exec.LookPath(bunRunner)
 	if err != nil {
 		return burrito.WrapError(
 			err, "Bun not found, download and install it from"+
 				" https://bun.com/")
 	}
-	cmd, err := exec.Command("bun", "--version").Output()
+	cmd, err := exec.Command(bunRunner, "--version").Output()
 	if err != nil {
 		return burrito.WrapError(err, "Failed to check Bun version")
 	}
@@ -119,8 +129,13 @@ func (f *BunFilterDefinition) InstallDependencies(parent *RemoteFilterDefinition
 	}
 	Logger.Infof("Downloading dependencies for %s...", f.Id)
 	if hasPackageJson(installLocation) {
+		userConfig, err := getCombinedUserConfig()
+		if err != nil {
+			return burrito.WrapError(err, getUserConfigError)
+		}
+		bunRunner := *userConfig.BunRunner
 		Logger.Info("Installing bun dependencies...")
-		err := RunSubProcess("bun", []string{"install", "--silent"}, installLocation, installLocation, ShortFilterName(f.Id))
+		err = RunSubProcess(bunRunner, []string{"install", "--silent"}, installLocation, installLocation, ShortFilterName(f.Id))
 		if err != nil {
 			return burrito.WrapErrorf(
 				err, "Failed to run bun and install dependencies."+

--- a/regolith/filter_deno.go
+++ b/regolith/filter_deno.go
@@ -39,9 +39,14 @@ func (f *DenoFilter) run(context RunContext) error {
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	denoRunner := *userConfig.DenoRunner
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
-			"deno",
+			denoRunner,
 			append([]string{
 				"run", "--allow-all",
 				context.AbsoluteLocation + string(os.PathSeparator) +
@@ -58,7 +63,7 @@ func (f *DenoFilter) run(context RunContext) error {
 	} else {
 		jsonSettings, _ := json.Marshal(f.Settings)
 		err := RunSubProcess(
-			"deno",
+			denoRunner,
 			append([]string{
 				"run", "--allow-all",
 				context.AbsoluteLocation + string(os.PathSeparator) +
@@ -95,13 +100,18 @@ func (f *DenoFilterDefinition) CreateFilterRunner(runConfiguration map[string]an
 }
 
 func (f *DenoFilterDefinition) Check(context RunContext) error {
-	_, err := exec.LookPath("deno")
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	denoRunner := *userConfig.DenoRunner
+	_, err = exec.LookPath(denoRunner)
 	if err != nil {
 		return burrito.WrapError(
 			err, "Deno not found, download and install it from"+
 				" https://deno.land/")
 	}
-	cmd, err := exec.Command("deno", "--version").Output()
+	cmd, err := exec.Command(denoRunner, "--version").Output()
 	if err != nil {
 		return burrito.WrapError(err, "Failed to check Deno version")
 	}

--- a/regolith/filter_dotnet.go
+++ b/regolith/filter_dotnet.go
@@ -43,9 +43,14 @@ func (f *DotNetFilter) run(context RunContext) error {
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	dotnetRunner := *userConfig.DotnetRunner
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
-			"dotnet",
+			dotnetRunner,
 			append(
 				[]string{
 					context.AbsoluteLocation + string(os.PathSeparator) +
@@ -63,7 +68,7 @@ func (f *DotNetFilter) run(context RunContext) error {
 	} else {
 		jsonSettings, _ := json.Marshal(f.Settings)
 		err := RunSubProcess(
-			"dotnet",
+			dotnetRunner,
 			append(
 				[]string{
 					context.AbsoluteLocation + string(os.PathSeparator) +
@@ -98,14 +103,19 @@ func (f *DotNetFilterDefinition) InstallDependencies(*RemoteFilterDefinition, st
 }
 
 func (f *DotNetFilterDefinition) Check(context RunContext) error {
-	_, err := exec.LookPath("dotnet")
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	dotnetRunner := *userConfig.DotnetRunner
+	_, err = exec.LookPath(dotnetRunner)
 	if err != nil {
 		return burrito.WrapError(
 			err,
 			".Net not found, download and install it"+
 				" from https://dotnet.microsoft.com/download")
 	}
-	cmd, err := exec.Command("dotnet", "--version").Output()
+	cmd, err := exec.Command(dotnetRunner, "--version").Output()
 	if err != nil {
 		return burrito.WrapError(err, "Failed to check .Net version")
 	}

--- a/regolith/filter_java.go
+++ b/regolith/filter_java.go
@@ -55,9 +55,14 @@ func (f *JavaFilter) run(context RunContext) error {
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	javaRunner := *userConfig.JavaRunner
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
-			"java",
+			javaRunner,
 			append(
 				[]string{
 					"-jar", context.AbsoluteLocation + string(os.PathSeparator) +
@@ -75,7 +80,7 @@ func (f *JavaFilter) run(context RunContext) error {
 	} else {
 		jsonSettings, _ := json.Marshal(f.Settings)
 		err := RunSubProcess(
-			"java",
+			javaRunner,
 			append(
 				[]string{
 					"-jar", context.AbsoluteLocation + string(os.PathSeparator) +
@@ -110,14 +115,19 @@ func (f *JavaFilterDefinition) InstallDependencies(*RemoteFilterDefinition, stri
 }
 
 func (f *JavaFilterDefinition) Check(context RunContext) error {
-	_, err := exec.LookPath("java")
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	javaRunner := *userConfig.JavaRunner
+	_, err = exec.LookPath(javaRunner)
 	if err != nil {
 		return burrito.WrapError(
 			err,
 			"Java not found, download and install it"+
 				" from https://adoptopenjdk.net/")
 	}
-	cmd, err := exec.Command("java", "-version").Output()
+	cmd, err := exec.Command(javaRunner, "-version").Output()
 	if err != nil {
 		return burrito.WrapError(err, "Failed to check Java version")
 	}

--- a/regolith/filter_nim.go
+++ b/regolith/filter_nim.go
@@ -57,9 +57,14 @@ func (f *NimFilter) run(context RunContext) error {
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	nimRunner := *userConfig.NimRunner
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
-			"nim",
+			nimRunner,
 			append([]string{
 				"-r", "c", "--hints:off", "--warnings:off", "--mm:orc",
 				context.AbsoluteLocation + string(os.PathSeparator) + f.Definition.Script},
@@ -75,7 +80,7 @@ func (f *NimFilter) run(context RunContext) error {
 	} else {
 		jsonSettings, _ := json.Marshal(f.Settings)
 		err := RunSubProcess(
-			"nim",
+			nimRunner,
 			append([]string{
 				"-r", "c", "--hints:off", "--warnings:off", "--mm:orc",
 				context.AbsoluteLocation + string(os.PathSeparator) +
@@ -140,9 +145,14 @@ func (f *NimFilterDefinition) InstallDependencies(
 	}
 	Logger.Debugf("Installing dependencies using nimble in %s", requirementsPath)
 	if hasNimble(requirementsPath) {
+		userConfig, err := getCombinedUserConfig()
+		if err != nil {
+			return burrito.WrapError(err, getUserConfigError)
+		}
+		nimbleRunner := *userConfig.NimbleRunner
 		Logger.Info("Installing nim dependencies...")
-		err := RunSubProcess(
-			"nimble", []string{"install", "-d", "-y"}, requirementsPath, requirementsPath, ShortFilterName(f.Id))
+		err = RunSubProcess(
+			nimbleRunner, []string{"install", "-d", "-y"}, requirementsPath, requirementsPath, ShortFilterName(f.Id))
 		if err != nil {
 			return burrito.WrapErrorf(
 				err, "Failed to run nimble to install dependencies of a filter.\n"+
@@ -155,14 +165,19 @@ func (f *NimFilterDefinition) InstallDependencies(
 }
 
 func (f *NimFilterDefinition) Check(context RunContext) error {
-	_, err := exec.LookPath("nim")
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	nimRunner := *userConfig.NimRunner
+	_, err = exec.LookPath(nimRunner)
 	if err != nil {
 		return burrito.WrapError(
 			err,
 			"Nim not found, download and install it from"+
 				" https://nim-lang.org/")
 	}
-	cmd, err := exec.Command("nim", "--version").Output()
+	cmd, err := exec.Command(nimRunner, "--version").Output()
 	if err != nil {
 		return burrito.WrapError(err, "Failed to check Nim version.")
 	}

--- a/regolith/filter_nodejs.go
+++ b/regolith/filter_nodejs.go
@@ -55,9 +55,14 @@ func (f *NodeJSFilter) run(context RunContext) error {
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	nodeRunner := *userConfig.NodeRunner
 	if len(f.Settings) == 0 {
 		err := RunSubProcess(
-			"node",
+			nodeRunner,
 			append([]string{
 				context.AbsoluteLocation + string(os.PathSeparator) +
 					f.Definition.Script},
@@ -73,7 +78,7 @@ func (f *NodeJSFilter) run(context RunContext) error {
 	} else {
 		jsonSettings, _ := json.Marshal(f.Settings)
 		err := RunSubProcess(
-			"node",
+			nodeRunner,
 			append([]string{
 				context.AbsoluteLocation + string(os.PathSeparator) +
 					f.Definition.Script,
@@ -133,8 +138,13 @@ func (f *NodeJSFilterDefinition) InstallDependencies(parent *RemoteFilterDefinit
 		requirementsPath = installPath
 	}
 	if hasPackageJson(requirementsPath) {
+		userConfig, err := getCombinedUserConfig()
+		if err != nil {
+			return burrito.WrapError(err, getUserConfigError)
+		}
+		npmRunner := *userConfig.NpmRunner
 		Logger.Info("Installing npm dependencies...")
-		err := RunSubProcess("npm", []string{"i", "--no-fund", "--no-audit"}, requirementsPath, requirementsPath, ShortFilterName(f.Id))
+		err = RunSubProcess(npmRunner, []string{"i", "--no-fund", "--no-audit"}, requirementsPath, requirementsPath, ShortFilterName(f.Id))
 		if err != nil {
 			return burrito.WrapErrorf(
 				err, "Failed to run npm and install dependencies."+
@@ -146,13 +156,18 @@ func (f *NodeJSFilterDefinition) InstallDependencies(parent *RemoteFilterDefinit
 }
 
 func (f *NodeJSFilterDefinition) Check(context RunContext) error {
-	_, err := exec.LookPath("node")
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return burrito.WrapError(err, getUserConfigError)
+	}
+	nodeRunner := *userConfig.NodeRunner
+	_, err = exec.LookPath(nodeRunner)
 	if err != nil {
 		return burrito.WrapError(
 			err, "NodeJS not found, download and install it from"+
 				" https://nodejs.org/en/")
 	}
-	cmd, err := exec.Command("node", "--version").Output()
+	cmd, err := exec.Command(nodeRunner, "--version").Output()
 	if err != nil {
 		return burrito.WrapError(err, "Failed to check NodeJS version")
 	}

--- a/regolith/filter_python.go
+++ b/regolith/filter_python.go
@@ -182,9 +182,9 @@ func (f *PythonFilterDefinition) InstallDependencies(
 		Logger.Info("Installing pip dependencies...")
 		requirementsFolder := filepath.Dir(requirementsFile)
 		err = RunSubProcess(
-			filepath.Join(venvPath, venvScriptsPath, "pip"+exeSuffix),
-			[]string{"install", "-r", filepath.Base(requirementsFile)}, requirementsFolder,
-			requirementsFolder, ShortFilterName(f.Id))
+			venvPythonCommand,
+			[]string{"-m", "pip", "install", "-r", filepath.Base(requirementsFile)},
+			requirementsFolder, requirementsFolder, ShortFilterName(f.Id))
 		if err != nil {
 			return burrito.WrapErrorf(
 				err, "Couldn't run Pip to install dependencies of %s",
@@ -241,8 +241,24 @@ func needsVenv(requirementsFilePath string) bool {
 	return false
 }
 
+// findPython returns the Python command to use. If PythonRunner is set in the
+// user config, it uses that value directly. Otherwise, it falls back to
+// trying the platform-specific pythonExeNames list.
 func findPython() (string, error) {
-	var err error
+	userConfig, err := getCombinedUserConfig()
+	if err != nil {
+		return "", burrito.WrapError(err, getUserConfigError)
+	}
+	if userConfig.PythonRunner != nil {
+		_, err = exec.LookPath(*userConfig.PythonRunner)
+		if err == nil {
+			return *userConfig.PythonRunner, nil
+		}
+		return "", burrito.WrappedErrorf(
+			"Python not found at configured path %q, download and install it from "+
+				"https://www.python.org/downloads/", *userConfig.PythonRunner)
+	}
+	// Fallback: try platform-specific executable names
 	for _, c := range pythonExeNames {
 		_, err = exec.LookPath(c)
 		if err == nil {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -762,6 +762,17 @@ func manageUserConfigEdit(index int, key, value string) error {
 			return burrito.WrappedError(userSettingIncorrectIndexUseError)
 		}
 		userConfig.TmpDir = &value
+	case "node_runner_override":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		if value != "nodejs" && value != "bun" && value != "deno" {
+			return burrito.WrappedErrorf(
+				"Invalid value for node_runner_override property.\n"+
+					"Value: %s\n"+
+					"Allowed values: nodejs, bun, deno", value)
+		}
+		userConfig.NodeRunnerOverride = &value
 	case "bun_runner":
 		if index != -1 {
 			return burrito.WrappedError(userSettingIncorrectIndexUseError)
@@ -854,6 +865,11 @@ func manageUserConfigDelete(index int, key string) error {
 			return burrito.WrappedError(userSettingIncorrectIndexUseError)
 		}
 		userConfig.TmpDir = nil
+	case "node_runner_override":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NodeRunnerOverride = nil
 	case "bun_runner":
 		if index != -1 {
 			return burrito.WrappedError(userSettingIncorrectIndexUseError)

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -762,6 +762,51 @@ func manageUserConfigEdit(index int, key, value string) error {
 			return burrito.WrappedError(userSettingIncorrectIndexUseError)
 		}
 		userConfig.TmpDir = &value
+	case "bun_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.BunRunner = &value
+	case "deno_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.DenoRunner = &value
+	case "dotnet_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.DotnetRunner = &value
+	case "java_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.JavaRunner = &value
+	case "nim_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NimRunner = &value
+	case "nimble_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NimbleRunner = &value
+	case "node_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NodeRunner = &value
+	case "npm_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NpmRunner = &value
+	case "python_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.PythonRunner = &value
 	default:
 		return burrito.WrappedErrorf(invalidUserConfigPropertyError, key)
 	}
@@ -785,12 +830,12 @@ func manageUserConfigDelete(index int, key string) error {
 	switch key {
 	case "use_project_app_data_storage":
 		if index != -1 {
-			return burrito.WrappedError("Cannot use --index with non-array property.")
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
 		}
 		userConfig.UseProjectAppDataStorage = nil
 	case "username":
 		if index != -1 {
-			return burrito.WrappedError("Cannot use --index with non-array property.")
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
 		}
 		userConfig.Username = nil
 	case "resolvers":
@@ -806,9 +851,54 @@ func manageUserConfigDelete(index int, key string) error {
 		}
 	case "tmp_dir":
 		if index != -1 {
-			return burrito.WrappedError("Cannot use --index with non-array property.")
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
 		}
 		userConfig.TmpDir = nil
+	case "bun_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.BunRunner = nil
+	case "deno_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.DenoRunner = nil
+	case "dotnet_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.DotnetRunner = nil
+	case "java_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.JavaRunner = nil
+	case "nim_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NimRunner = nil
+	case "nimble_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NimbleRunner = nil
+	case "node_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NodeRunner = nil
+	case "npm_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NpmRunner = nil
+	case "python_runner":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.PythonRunner = nil
 	default:
 		return burrito.WrappedErrorf(invalidUserConfigPropertyError, key)
 	}

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -49,6 +49,10 @@ type UserConfig struct {
 	// the project in .regolith directory.
 	TmpDir *string `json:"tmp_dir,omitempty"`
 
+	// NodeRunnerOverride is an option that lets you override the Node runner
+	// to run filters with Bun or Deno
+	NodeRunnerOverride *string `json:"node_runner_override,omitempty"`
+
 	// BunRunner is optional path for Regolith to look for Bun to run filters.
 	BunRunner *string `json:"bun_runner,omitempty"`
 
@@ -87,6 +91,7 @@ func NewUserConfig() *UserConfig {
 		ResolverCacheUpdateCooldown: nil,
 		FilterCacheUpdateCooldown:   nil,
 		TmpDir:                      nil,
+		NodeRunnerOverride:          nil,
 		BunRunner:                   nil,
 		DenoRunner:                  nil,
 		DotnetRunner:                nil,
@@ -110,6 +115,8 @@ func (u *UserConfig) String() string {
 	extra, _ = u.stringPropertyValue("filter_cache_update_cooldown")
 	result += "\n" + extra
 	extra, _ = u.stringPropertyValue("tmp_dir")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("node_runner_override")
 	result += "\n" + extra
 	extra, _ = u.stringPropertyValue("bun_runner")
 	result += "\n" + extra
@@ -175,6 +182,12 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 			value = fmt.Sprintf("%v", *u.TmpDir)
 		}
 		return fmt.Sprintf("tmp_dir: %v", value), nil
+	case "node_runner_override":
+		value := "null"
+		if u.NodeRunnerOverride != nil {
+			value = fmt.Sprintf("%v", *u.NodeRunnerOverride)
+		}
+		return fmt.Sprintf("node_runner_override: %v", value), nil
 	case "bun_runner":
 		value := "null"
 		if u.BunRunner != nil {
@@ -256,10 +269,10 @@ func (u *UserConfig) fillDefaults() {
 		u.TmpDir = new(string)
 		*u.TmpDir = ""
 	}
-
-	// WARNING: It's CRITICAL to set the default values for the runners, the
-	// filters code dereferences the values received from
-	// getCombinedUserConfig() with assumption that they are not nil.
+	if u.NodeRunnerOverride == nil {
+		u.NodeRunnerOverride = new(string)
+		*u.NodeRunnerOverride = "nodejs"
+	}
 	if u.BunRunner == nil {
 		u.BunRunner = new(string)
 		*u.BunRunner = "bun"

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
 )
@@ -47,6 +48,35 @@ type UserConfig struct {
 	// for running filters. When not set, the tmp directory will be placed inside
 	// the project in .regolith directory.
 	TmpDir *string `json:"tmp_dir,omitempty"`
+
+	// BunRunner is optional path for Regolith to look for Bun to run filters.
+	BunRunner *string `json:"bun_runner,omitempty"`
+
+	// DenoRunner is optional path for Regolith to look for Deno to run filters.
+	DenoRunner *string `json:"deno_runner,omitempty"`
+
+	// DotnetRunner is optional path for Regolith to look for .Net to run filters.
+	DotnetRunner *string `json:"dotnet_runner,omitempty"`
+
+	// JavaRunner is optional path for Regolith to look for Java to run filters.
+	JavaRunner *string `json:"java_runner,omitempty"`
+
+	// NimRunner is optional path for Regolith to look for Nim to run filters.
+	NimRunner *string `json:"nim_runner,omitempty"`
+
+	// NimbleRunner is optional path for Regolith to look for Nimble to install Nim dependencies.
+	NimbleRunner *string `json:"nimble_runner,omitempty"`
+
+	// NodeRunner is optional path for Regolith to look for Node to run filters.
+	NodeRunner *string `json:"node_runner,omitempty"`
+
+	// NpmRunner is optional path for Regolith to look for Npm to install Node dependencies.
+	NpmRunner *string `json:"npm_runner,omitempty"`
+
+	// PythonRunner is optional path for Regolith to look for Python to run
+	// filters. When nil, Regolith tries the platform-specific executable names
+	// (e.g. python3, python).
+	PythonRunner *string `json:"python_runner,omitempty"`
 }
 
 func NewUserConfig() *UserConfig {
@@ -57,6 +87,15 @@ func NewUserConfig() *UserConfig {
 		ResolverCacheUpdateCooldown: nil,
 		FilterCacheUpdateCooldown:   nil,
 		TmpDir:                      nil,
+		BunRunner:                   nil,
+		DenoRunner:                  nil,
+		DotnetRunner:                nil,
+		JavaRunner:                  nil,
+		NimRunner:                   nil,
+		NimbleRunner:                nil,
+		NodeRunner:                  nil,
+		NpmRunner:                   nil,
+		PythonRunner:                nil,
 	}
 }
 
@@ -71,6 +110,24 @@ func (u *UserConfig) String() string {
 	extra, _ = u.stringPropertyValue("filter_cache_update_cooldown")
 	result += "\n" + extra
 	extra, _ = u.stringPropertyValue("tmp_dir")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("bun_runner")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("deno_runner")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("dotnet_runner")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("java_runner")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("nim_runner")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("nimble_runner")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("node_runner")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("npm_runner")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("python_runner")
 	result += "\n" + extra
 	return result
 }
@@ -118,6 +175,61 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 			value = fmt.Sprintf("%v", *u.TmpDir)
 		}
 		return fmt.Sprintf("tmp_dir: %v", value), nil
+	case "bun_runner":
+		value := "null"
+		if u.BunRunner != nil {
+			value = fmt.Sprintf("%v", *u.BunRunner)
+		}
+		return fmt.Sprintf("bun_runner: %v", value), nil
+	case "deno_runner":
+		value := "null"
+		if u.DenoRunner != nil {
+			value = fmt.Sprintf("%v", *u.DenoRunner)
+		}
+		return fmt.Sprintf("deno_runner: %v", value), nil
+	case "dotnet_runner":
+		value := "null"
+		if u.DotnetRunner != nil {
+			value = fmt.Sprintf("%v", *u.DotnetRunner)
+		}
+		return fmt.Sprintf("dotnet_runner: %v", value), nil
+	case "java_runner":
+		value := "null"
+		if u.JavaRunner != nil {
+			value = fmt.Sprintf("%v", *u.JavaRunner)
+		}
+		return fmt.Sprintf("java_runner: %v", value), nil
+	case "nim_runner":
+		value := "null"
+		if u.NimRunner != nil {
+			value = fmt.Sprintf("%v", *u.NimRunner)
+		}
+		return fmt.Sprintf("nim_runner: %v", value), nil
+	case "nimble_runner":
+		value := "null"
+		if u.NimbleRunner != nil {
+			value = fmt.Sprintf("%v", *u.NimbleRunner)
+		}
+		return fmt.Sprintf("nimble_runner: %v", value), nil
+	case "node_runner":
+		value := "null"
+		if u.NodeRunner != nil {
+			value = fmt.Sprintf("%v", *u.NodeRunner)
+		}
+		return fmt.Sprintf("node_runner: %v", value), nil
+	case "npm_runner":
+		value := "null"
+		if u.NpmRunner != nil {
+			value = fmt.Sprintf("%v", *u.NpmRunner)
+		}
+		return fmt.Sprintf("npm_runner: %v", value), nil
+	case "python_runner":
+		if u.PythonRunner != nil {
+			return fmt.Sprintf("python_runner: %v", *u.PythonRunner), nil
+		}
+		return fmt.Sprintf(
+			"python_runner: null (attempts to run %s)",
+			strings.Join(pythonExeNames, ", ")), nil
 	}
 	return "", burrito.WrapErrorf(nil, invalidUserConfigPropertyError, name)
 }
@@ -144,6 +256,44 @@ func (u *UserConfig) fillDefaults() {
 		u.TmpDir = new(string)
 		*u.TmpDir = ""
 	}
+
+	// WARNING: It's CRITICAL to set the default values for the runners, the
+	// filters code dereferences the values received from
+	// getCombinedUserConfig() with assumption that they are not nil.
+	if u.BunRunner == nil {
+		u.BunRunner = new(string)
+		*u.BunRunner = "bun"
+	}
+	if u.DenoRunner == nil {
+		u.DenoRunner = new(string)
+		*u.DenoRunner = "deno"
+	}
+	if u.DotnetRunner == nil {
+		u.DotnetRunner = new(string)
+		*u.DotnetRunner = "dotnet"
+	}
+	if u.JavaRunner == nil {
+		u.JavaRunner = new(string)
+		*u.JavaRunner = "java"
+	}
+	if u.NimRunner == nil {
+		u.NimRunner = new(string)
+		*u.NimRunner = "nim"
+	}
+	if u.NimbleRunner == nil {
+		u.NimbleRunner = new(string)
+		*u.NimbleRunner = "nimble"
+	}
+	if u.NodeRunner == nil {
+		u.NodeRunner = new(string)
+		*u.NodeRunner = "node"
+	}
+	if u.NpmRunner == nil {
+		u.NpmRunner = new(string)
+		*u.NpmRunner = "npm"
+	}
+	// PythonRunner intentionally has no default (nil = auto-detect).
+	// When nil, findPython() falls back to the platform-specific pythonExeNames list.
 	// Make sure resolvers is not nil and append the default resolver
 	if u.Resolvers == nil {
 		u.Resolvers = []string{}


### PR DESCRIPTION
Added user settings for specifying the path to the runners for executing filters:
- bun
- deno
- dotnet
- java
- nim
- nimble (for installing nim packages)
- node
- npm (for installing npm packages)
- python (python finds pip using 'python -m pip' command, instead of calling pip directly like it used to)

**Example usage:**
```
regolith config python_runner "C:/Programs/pypy3.11-v7.3.21-win64/pypy.exe"
```
---

Added new `node_runner_override` option to force Regolith to run NodeJS filters with Bun/Deno

**Example usage:**
```
regolith config node_runner_override bun
```

---
I wanted to make the `node_runner_override` to be able to fallback to another runner, but then I realized that when filter crashes, it could have already made some changes so this is simply not an option.

This implementation doesn't let you select override option per filter so if just one of the filters is incompatible with Deno/Bun that unfortunately means that the user has to either disable this option or stop using that filter. I don't want to make this a project setting. We could discuss alternative solutions. Perhaps a map filter_name->runner would work work, but currently the `regolith config` command doesn't support advanced configuration settings like that.
