### PR TITLE
Option to override Node runner with Deno or Bun

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,12 +148,14 @@ The behavior of the command changes based on the used flags and the number of pr
 The cheatsheet below shows the possible combinations of flags and arguments and what they do:
 
 Printing all properties:                        regolith config
-Printing specified property:                    regolith config <key>
-Setting property value:                         regolith config <key> <value>
-Deleting a property:                            regolith config <key> --delete
-Appending to a list property:                   regolith config <key> <value> --append
-Replacing item in a list property:              regolith config <key> <value> --index <index>
-Deleting item in a list property:               regolith config <key> --index <index> --delete
+Printing specified property:                    regolith config <setting>
+Setting property value:                         regolith config <setting> <value>
+Deleting a property:                            regolith config <setting> --delete
+Appending to a list property:                   regolith config <setting> <value> --append
+Replacing item in a list property:              regolith config <setting> <value> --index <index>
+Deleting item in a list property:               regolith config <setting> --index <index> --delete
+Setting a value in a map property:             	regolith config <setting> <key> <value>
+Deleting a value in a map property:            	regolith config <setting> <key> --delete
 
 The printing commands can take the --full flag to print configuration with the default values
 included (if they're not defined in the config file). Without the flag, the undefined properties

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -275,5 +275,9 @@ const (
 	// when changing the user settings.
 	userSettingIncorrectIndexUseError = "Cannot use --index with non-array property."
 
+	// userSettingIncorrectKeyUseError is used when the user tries to use the --key flag with a non-map property
+	// when changing the user settings.
+	userSettingIncorrectKeyUseError = "Cannot use <key> with non-map property."
+
 	getRunnerError = "Failed to get the path to filter runner."
 )

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -337,6 +337,15 @@ var filterInstallerFactories = map[string]filterInstallerFactory{
 
 func FilterInstallerFromObject(id string, obj map[string]any) (FilterInstaller, error) {
 	runWith, _ := obj["runWith"].(string)
+	if runWith == "nodejs" {
+		userConfig, err := getCombinedUserConfig()
+		if err != nil {
+			return nil, burrito.WrapError(err, getUserConfigError)
+		}
+		if userConfig.NodeRunnerOverride != nil {
+			runWith = *userConfig.NodeRunnerOverride
+		}
+	}
 	if factory, ok := filterInstallerFactories[runWith]; ok {
 		filter, err := factory.constructor(id, obj)
 		if err != nil {

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -343,7 +343,14 @@ func FilterInstallerFromObject(id string, obj map[string]any) (FilterInstaller, 
 			return nil, burrito.WrapError(err, getUserConfigError)
 		}
 		if userConfig.NodeRunnerOverride != nil {
-			runWith = *userConfig.NodeRunnerOverride
+			defaultOverride, ok := userConfig.NodeRunnerOverride["*"]
+			if ok {
+				runWith = defaultOverride
+			}
+			override, ok := userConfig.NodeRunnerOverride[id]
+			if ok {
+				runWith = override
+			}
 		}
 	}
 	if factory, ok := filterInstallerFactories[runWith]; ok {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -762,6 +762,17 @@ func manageUserConfigEdit(index int, key, value string) error {
 			return burrito.WrappedError(userSettingIncorrectIndexUseError)
 		}
 		userConfig.TmpDir = &value
+	case "node_runner_override":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		if value != "nodejs" && value != "bun" && value != "deno" {
+			return burrito.WrappedErrorf(
+				"Invalid value for node_runner_override property.\n"+
+					"Value: %s\n"+
+					"Allowed values: nodejs, bun, deno", value)
+		}
+		userConfig.NodeRunnerOverride = &value
 	default:
 		return burrito.WrappedErrorf(invalidUserConfigPropertyError, key)
 	}
@@ -809,6 +820,11 @@ func manageUserConfigDelete(index int, key string) error {
 			return burrito.WrappedError("Cannot use --index with non-array property.")
 		}
 		userConfig.TmpDir = nil
+	case "node_runner_override":
+		if index != -1 {
+			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		}
+		userConfig.NodeRunnerOverride = nil
 	default:
 		return burrito.WrappedErrorf(invalidUserConfigPropertyError, key)
 	}

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -635,7 +635,7 @@ func UpdateResolvers(debug bool, env string) error {
 
 // manageUserConfigPrint is a helper function for ManageConfig used to print
 // the specified value from the user configuration.
-func manageUserConfigPrint(full bool, key string) error {
+func manageUserConfigPrint(full bool, setting string) error {
 	var err error // prevent shadowing
 	configPath := ""
 	userConfig := NewUserConfig()
@@ -653,9 +653,9 @@ func manageUserConfigPrint(full bool, key string) error {
 		fmt.Printf("\nGLOBAL USER CONFIGURATION: %s\n", configPath)
 		userConfig.fillWithFileData(configPath)
 	}
-	result, err := userConfig.stringPropertyValue(key)
+	result, err := userConfig.stringPropertyValue(setting)
 	if err != nil {
-		return burrito.WrapErrorf(err, invalidUserConfigPropertyError, key)
+		return burrito.WrapErrorf(err, invalidUserConfigPropertyError, setting)
 	}
 	result = "\t" + strings.ReplaceAll(result, "\n", "\n\t") // Indent
 	fmt.Println(result)
@@ -692,7 +692,7 @@ func manageUserConfigPrintAll(full bool) error {
 
 // manageUserConfigEdit is a helper function for ManageConfig used to edit
 // the specified value from the user configuration.
-func manageUserConfigEdit(index int, key, value string) error {
+func manageUserConfigEdit(setting string, index int, key, value string) error {
 	configPath, err := getGlobalUserConfigPath()
 	if err != nil {
 		return burrito.WrapError(err, getGlobalUserConfigPathError)
@@ -700,11 +700,18 @@ func manageUserConfigEdit(index int, key, value string) error {
 	Logger.Infof("Editing user configuration.\n\tPath: %s", configPath)
 	userConfig := NewUserConfig()
 	userConfig.fillWithFileData(configPath)
-	switch key {
+
+	// Only list properties can use 'index'
+	if setting != "resolvers" && index != -1 {
+		return burrito.WrappedError(userSettingIncorrectIndexUseError)
+	}
+	// Only map properties can use 'key'
+	if setting != "node_runner_override" && key != "" {
+		return burrito.WrappedError(userSettingIncorrectKeyUseError)
+	}
+
+	switch setting {
 	case "use_project_app_data_storage":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		boolValue, err := strconv.ParseBool(value)
 		if err != nil {
 			return burrito.WrapErrorf(err, "Invalid value for boolean property.\n"+
@@ -712,14 +719,8 @@ func manageUserConfigEdit(index int, key, value string) error {
 		}
 		userConfig.UseProjectAppDataStorage = &boolValue
 	case "username":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.Username = &value
 	case "resolver_cache_update_cooldown":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		_, err = time.ParseDuration(value)
 		if err != nil {
 			return burrito.WrapErrorf(err, "Invalid value for duration property.\n"+
@@ -727,9 +728,6 @@ func manageUserConfigEdit(index int, key, value string) error {
 		}
 		userConfig.ResolverCacheUpdateCooldown = &value
 	case "filter_cache_update_cooldown":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		_, err = time.ParseDuration(value)
 		if err != nil {
 			return burrito.WrapErrorf(err, "Invalid value for duration property.\n"+
@@ -758,68 +756,38 @@ func manageUserConfigEdit(index int, key, value string) error {
 			}
 		}
 	case "tmp_dir":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.TmpDir = &value
 	case "node_runner_override":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		if value != "nodejs" && value != "bun" && value != "deno" {
 			return burrito.WrappedErrorf(
 				"Invalid value for node_runner_override property.\n"+
 					"Value: %s\n"+
 					"Allowed values: nodejs, bun, deno", value)
 		}
-		userConfig.NodeRunnerOverride = &value
-	case "bun_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		if key == "" {
+			return burrito.WrappedErrorf("Key is required for setting node_runner_override property.")
 		}
+		userConfig.NodeRunnerOverride[key] = value
+	case "bun_runner":
 		userConfig.BunRunner = &value
 	case "deno_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.DenoRunner = &value
 	case "dotnet_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.DotnetRunner = &value
 	case "java_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.JavaRunner = &value
 	case "nim_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.NimRunner = &value
 	case "nimble_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.NimbleRunner = &value
 	case "node_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.NodeRunner = &value
 	case "npm_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.NpmRunner = &value
 	case "python_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.PythonRunner = &value
 	default:
-		return burrito.WrappedErrorf(invalidUserConfigPropertyError, key)
+		return burrito.WrappedErrorf(invalidUserConfigPropertyError, setting)
 	}
 	err = userConfig.dump(configPath)
 	if err != nil {
@@ -830,7 +798,7 @@ func manageUserConfigEdit(index int, key, value string) error {
 
 // manageUserConfigDelete is a helper function for ManageConfig used to delete
 // the specified value from the user configuration.
-func manageUserConfigDelete(index int, key string) error {
+func manageUserConfigDelete(setting string, index int, key string) error {
 	configPath, err := getGlobalUserConfigPath()
 	if err != nil {
 		return burrito.WrapError(err, getGlobalUserConfigPathError)
@@ -838,16 +806,20 @@ func manageUserConfigDelete(index int, key string) error {
 	Logger.Infof("Editing user configuration.\n\tPath: %s", configPath)
 	userConfig := NewUserConfig()
 	userConfig.fillWithFileData(configPath)
-	switch key {
+
+	// Only list properties can use 'index'
+	if setting != "resolvers" && index != -1 {
+		return burrito.WrappedError(userSettingIncorrectIndexUseError)
+	}
+	// Only map properties can use 'key'
+	if setting != "node_runner_override" && key != "" {
+		return burrito.WrappedError(userSettingIncorrectKeyUseError)
+	}
+
+	switch setting {
 	case "use_project_app_data_storage":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.UseProjectAppDataStorage = nil
 	case "username":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.Username = nil
 	case "resolvers":
 		if index == -1 {
@@ -861,62 +833,36 @@ func manageUserConfigDelete(index int, key string) error {
 				userConfig.Resolvers[index+1:]...)
 		}
 	case "tmp_dir":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.TmpDir = nil
 	case "node_runner_override":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
+		// Don't allow deleting everything because it's too destructive, and
+		// it could easily destroy someone's config by accident.
+		if key == "" {
+			return burrito.WrappedErrorf(
+				"Providing <key> is required for deleting elements from the " +
+					"node_runner_override setting.")
 		}
-		userConfig.NodeRunnerOverride = nil
+		delete(userConfig.NodeRunnerOverride, key)
 	case "bun_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.BunRunner = nil
 	case "deno_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.DenoRunner = nil
 	case "dotnet_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.DotnetRunner = nil
 	case "java_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.JavaRunner = nil
 	case "nim_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.NimRunner = nil
 	case "nimble_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.NimbleRunner = nil
 	case "node_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.NodeRunner = nil
 	case "npm_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.NpmRunner = nil
 	case "python_runner":
-		if index != -1 {
-			return burrito.WrappedError(userSettingIncorrectIndexUseError)
-		}
 		userConfig.PythonRunner = nil
 	default:
-		return burrito.WrappedErrorf(invalidUserConfigPropertyError, key)
+		return burrito.WrappedErrorf(invalidUserConfigPropertyError, setting)
 	}
 	err = userConfig.dump(configPath)
 	if err != nil {
@@ -978,11 +924,10 @@ func ManageConfig(debug, full, delete, append bool, index int, args []string, en
 			if full {
 				return burrito.WrappedError("The --full flag is only valid for printing.")
 			}
-			err = manageUserConfigDelete(index, args[0])
+			err = manageUserConfigDelete(args[0], index, "")
 			if err != nil {
 				return burrito.PassError(err)
 			}
-			return nil
 		} else {
 			if index != -1 {
 				return burrito.WrappedError("The --index flag is not allowed for printing.")
@@ -991,10 +936,32 @@ func ManageConfig(debug, full, delete, append bool, index int, args []string, en
 			if err != nil {
 				return burrito.PassError(err)
 			}
-			return nil
 		}
+		return nil
 	} else if len(args) == 2 {
 		// 2 ARGUMENTS - Set or append
+
+		// Check illegal flags
+		if full {
+			return burrito.WrappedError("The --full flag is only valid for printing.")
+		}
+
+		// Delete
+		if delete {
+			err = manageUserConfigDelete(args[0], index, args[1])
+			if err != nil {
+				return burrito.PassError(err)
+			}
+		} else {
+			// Set or append
+			err = manageUserConfigEdit(args[0], index, "", args[1])
+			if err != nil {
+				return burrito.PassError(err)
+			}
+		}
+		return nil
+	} else if len(args) == 3 {
+		// 3 ARGUMENTS - Set (map property)
 
 		// Check illegal flags
 		if delete {
@@ -1003,9 +970,11 @@ func ManageConfig(debug, full, delete, append bool, index int, args []string, en
 		if full {
 			return burrito.WrappedError("The --full flag is only valid for printing.")
 		}
+		if append {
+			return burrito.WrappedError("The --append flag is only valid for array properties.")
+		}
 
-		// Set or append
-		err = manageUserConfigEdit(index, args[0], args[1])
+		err = manageUserConfigEdit(args[0], index, args[1], args[2])
 		if err != nil {
 			return burrito.PassError(err)
 		}

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -47,6 +47,10 @@ type UserConfig struct {
 	// for running filters. When not set, the tmp directory will be placed inside
 	// the project in .regolith directory.
 	TmpDir *string `json:"tmp_dir,omitempty"`
+
+	// NodeRunnerOverride is an option that lets you override the Node runner
+	// to run filters with Bun or Deno
+	NodeRunnerOverride *string `json:"node_runner_override,omitempty"`
 }
 
 func NewUserConfig() *UserConfig {
@@ -57,6 +61,7 @@ func NewUserConfig() *UserConfig {
 		ResolverCacheUpdateCooldown: nil,
 		FilterCacheUpdateCooldown:   nil,
 		TmpDir:                      nil,
+		NodeRunnerOverride:          nil,
 	}
 }
 
@@ -71,6 +76,8 @@ func (u *UserConfig) String() string {
 	extra, _ = u.stringPropertyValue("filter_cache_update_cooldown")
 	result += "\n" + extra
 	extra, _ = u.stringPropertyValue("tmp_dir")
+	result += "\n" + extra
+	extra, _ = u.stringPropertyValue("node_runner_override")
 	result += "\n" + extra
 	return result
 }
@@ -118,6 +125,12 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 			value = fmt.Sprintf("%v", *u.TmpDir)
 		}
 		return fmt.Sprintf("tmp_dir: %v", value), nil
+	case "node_runner_override":
+		value := "null"
+		if u.NodeRunnerOverride != nil {
+			value = fmt.Sprintf("%v", *u.NodeRunnerOverride)
+		}
+		return fmt.Sprintf("node_runner_override: %v", value), nil
 	}
 	return "", burrito.WrapErrorf(nil, invalidUserConfigPropertyError, name)
 }

--- a/regolith/user_config.go
+++ b/regolith/user_config.go
@@ -50,7 +50,7 @@ type UserConfig struct {
 
 	// NodeRunnerOverride is an option that lets you override the Node runner
 	// to run filters with Bun or Deno
-	NodeRunnerOverride *string `json:"node_runner_override,omitempty"`
+	NodeRunnerOverride map[string]string `json:"node_runner_override,omitempty"`
 
 	// BunRunner is optional path for Regolith to look for Bun to run filters.
 	BunRunner *string `json:"bun_runner,omitempty"`
@@ -90,7 +90,7 @@ func NewUserConfig() *UserConfig {
 		ResolverCacheUpdateCooldown: nil,
 		FilterCacheUpdateCooldown:   nil,
 		TmpDir:                      nil,
-		NodeRunnerOverride:          nil,
+		NodeRunnerOverride:          map[string]string{},
 		BunRunner:                   nil,
 		DenoRunner:                  nil,
 		DotnetRunner:                nil,
@@ -182,11 +182,23 @@ func (u *UserConfig) stringPropertyValue(name string) (string, error) {
 		}
 		return fmt.Sprintf("tmp_dir: %v", value), nil
 	case "node_runner_override":
-		value := "null"
-		if u.NodeRunnerOverride != nil {
-			value = fmt.Sprintf("%v", *u.NodeRunnerOverride)
+		if len(u.NodeRunnerOverride) == 0 {
+			return "node_runner_override: {}", nil
 		}
-		return fmt.Sprintf("node_runner_override: %v", value), nil
+		result := "node_runner_override: \n"
+		// Print default value first
+		defaultVal, ok := u.NodeRunnerOverride["*"]
+		if ok {
+			result += fmt.Sprintf("\t- * => %v\n", defaultVal)
+		}
+		// Other values...
+		for k, v := range u.NodeRunnerOverride {
+			if k == "*" {
+				continue
+			}
+			result += fmt.Sprintf("\t- %v => %v\n", k, v)
+		}
+		return result, nil
 	case "bun_runner":
 		value := "null"
 		if u.BunRunner != nil {
@@ -267,7 +279,9 @@ func (u *UserConfig) fillDefaults() {
 		u.TmpDir = new(string)
 		*u.TmpDir = ""
 	}
-	// Make sure resolvers is not nil and append the default resolver
+	if u.NodeRunnerOverride == nil {
+		u.NodeRunnerOverride = map[string]string{}
+	}
 	if u.Resolvers == nil {
 		u.Resolvers = []string{}
 	}


### PR DESCRIPTION
#354 had two different features in one PR. This and the next PR are created to separate them.

---

Added new `node_runner_override` option to force Regolith to run NodeJS filters with Bun/Deno

**Example usage:**
```
regolith config node_runner_override bun
```
