### PR TITLE
Faster compile times + Fix issue with junctions + --unsafe flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/exp v0.0.0-20230131013936-aae9b4e6329d // indirect
-	golang.org/x/sync v0.8.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -410,6 +410,7 @@ func main() {
 			&regolith.EnabledExperiments, "experiments", nil,
 			"Enables experimental features. Currently supported experiments:\n"+
 				strings.Join(experimentDescs, "\n"))
+		cmd.Flags().BoolVar(&regolith.UnsafeMode, "unsafe", false, "Disables file protection safety checks for faster exports")
 	}
 
 	// Build and run CLI

--- a/main.go
+++ b/main.go
@@ -292,7 +292,6 @@ func main() {
 	subcommands = append(subcommands, cmdInstallAll)
 
 	// regolith run
-	var runUnsafe bool
 	cmdRun := &cobra.Command{
 		Use:   "run [profile_name]",
 		Short: "Runs Regolith using specified profile",
@@ -305,14 +304,14 @@ func main() {
 				extraFilterArgs = args[1:]
 			}
 			env, _ := cmd.Flags().GetString("env")
-			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env, runUnsafe)
+			unsafe, _ := cmd.Flags().GetBool("unsafe")
+			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env, unsafe)
 		},
 	}
-	cmdRun.Flags().BoolVar(&runUnsafe, "unsafe", false, "Disables file protection safety checks for faster exports")
+	cmdRun.Flags().Bool("unsafe", false, "Disables file protection safety checks for faster exports")
 	subcommands = append(subcommands, cmdRun)
 
 	// regolith watch
-	var watchUnsafe bool
 	cmdWatch := &cobra.Command{
 		Use:   "watch [profile_name]",
 		Short: "Watches project files and automatically runs Regolith when they change",
@@ -325,10 +324,11 @@ func main() {
 				extraFilterArgs = args[1:]
 			}
 			env, _ := cmd.Flags().GetString("env")
-			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env, watchUnsafe)
+			unsafe, _ := cmd.Flags().GetBool("unsafe")
+			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env, unsafe)
 		},
 	}
-	cmdWatch.Flags().BoolVar(&watchUnsafe, "unsafe", false, "Disables file protection safety checks for faster exports")
+	cmdWatch.Flags().Bool("unsafe", false, "Disables file protection safety checks for faster exports")
 	subcommands = append(subcommands, cmdWatch)
 
 	// regolith apply-filter

--- a/main.go
+++ b/main.go
@@ -292,6 +292,7 @@ func main() {
 	subcommands = append(subcommands, cmdInstallAll)
 
 	// regolith run
+	var runUnsafe bool
 	cmdRun := &cobra.Command{
 		Use:   "run [profile_name]",
 		Short: "Runs Regolith using specified profile",
@@ -304,12 +305,14 @@ func main() {
 				extraFilterArgs = args[1:]
 			}
 			env, _ := cmd.Flags().GetString("env")
-			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env)
+			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env, runUnsafe)
 		},
 	}
+	cmdRun.Flags().BoolVar(&runUnsafe, "unsafe", false, "Disables file protection safety checks for faster exports")
 	subcommands = append(subcommands, cmdRun)
 
 	// regolith watch
+	var watchUnsafe bool
 	cmdWatch := &cobra.Command{
 		Use:   "watch [profile_name]",
 		Short: "Watches project files and automatically runs Regolith when they change",
@@ -322,9 +325,10 @@ func main() {
 				extraFilterArgs = args[1:]
 			}
 			env, _ := cmd.Flags().GetString("env")
-			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env)
+			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env, watchUnsafe)
 		},
 	}
+	cmdWatch.Flags().BoolVar(&watchUnsafe, "unsafe", false, "Disables file protection safety checks for faster exports")
 	subcommands = append(subcommands, cmdWatch)
 
 	// regolith apply-filter
@@ -410,7 +414,6 @@ func main() {
 			&regolith.EnabledExperiments, "experiments", nil,
 			"Enables experimental features. Currently supported experiments:\n"+
 				strings.Join(experimentDescs, "\n"))
-		cmd.Flags().BoolVar(&regolith.UnsafeMode, "unsafe", false, "Disables file protection safety checks for faster exports")
 	}
 
 	// Build and run CLI

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -259,6 +259,8 @@ const (
 		"Resource pack export path: %s\n" +
 		"Behavior pack export path: %s"
 
+	updatedFilesUpdateError = "Failed to create a list of files edited by Regolith."
+
 	updatedFilesDumpError = "Failed to update the list of the files edited by Regolith." +
 		"This may cause the next run to fail."
 

--- a/regolith/experiments.go
+++ b/regolith/experiments.go
@@ -35,7 +35,10 @@ var AvailableExperiments = map[Experiment]ExperimentInfo{
 	SymlinkExport: {"symlink_export", symlinkExportDesc},
 }
 
-var EnabledExperiments []string
+var (
+	EnabledExperiments []string
+	UnsafeMode         bool
+)
 
 func IsExperimentEnabled(exp Experiment) bool {
 	if EnabledExperiments == nil {

--- a/regolith/experiments.go
+++ b/regolith/experiments.go
@@ -35,10 +35,7 @@ var AvailableExperiments = map[Experiment]ExperimentInfo{
 	SymlinkExport: {"symlink_export", symlinkExportDesc},
 }
 
-var (
-	EnabledExperiments []string
-	UnsafeMode         bool
-)
+var EnabledExperiments []string
 
 func IsExperimentEnabled(exp Experiment) bool {
 	if EnabledExperiments == nil {

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -247,7 +247,7 @@ func ExportProject(ctx RunContext) error {
 	// Load edited files
 	MeasureStart("Export - CheckDeletionSafety")
 	editedFiles := LoadEditedFiles(dotRegolithPath)
-	if !IsExperimentEnabled(SymlinkExport) && !UnsafeMode {
+	if !IsExperimentEnabled(SymlinkExport) && !ctx.UnsafeMode {
 		err = editedFiles.CheckDeletionSafety(rpPath, bpPath)
 		if err != nil {
 			return burrito.WrapErrorf(

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -247,12 +247,14 @@ func ExportProject(ctx RunContext) error {
 	// Load edited files
 	MeasureStart("Export - CheckDeletionSafety")
 	editedFiles := LoadEditedFiles(dotRegolithPath)
-	err = editedFiles.CheckDeletionSafety(rpPath, bpPath)
-	if err != nil {
-		return burrito.WrapErrorf(
-			err,
-			checkDeletionSafetyError,
-			rpPath, bpPath)
+	if !IsExperimentEnabled(SymlinkExport) && !UnsafeMode {
+		err = editedFiles.CheckDeletionSafety(rpPath, bpPath)
+		if err != nil {
+			return burrito.WrapErrorf(
+				err,
+				checkDeletionSafetyError,
+				rpPath, bpPath)
+		}
 	}
 	// Export RP and BP if necessary
 	if IsExperimentEnabled(SymlinkExport) {
@@ -270,12 +272,9 @@ func ExportProject(ctx RunContext) error {
 		return burrito.PassError(err)
 	}
 	MeasureStart("Export - EditedFiles.UpdateFromPaths")
-	// Update or create edited_files.json
 	err = editedFiles.UpdateFromPaths(rpPath, bpPath)
 	if err != nil {
-		return burrito.WrapError(
-			err,
-			"Failed to create a list of files edited by this 'regolith run'")
+		return burrito.WrapError(err, updatedFilesUpdateError)
 	}
 	err = editedFiles.Dump(dotRegolithPath)
 	if err != nil {

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -312,14 +312,12 @@ func exportProjectRpAndBp(profile Profile, rpPath, bpPath string, ctx RunContext
 	if !IsExperimentEnabled(SizeTimeCheck) {
 		// Clearing output locations
 		MeasureStart("Export - Clean")
-		err = os.RemoveAll(bpPath)
-		if err != nil {
+		if err := removeJunctionSafe(bpPath); err != nil {
 			return burrito.WrapErrorf(
 				err, "Failed to clear behavior pack from build path %q.\n"+
 					"Are user permissions correct?", bpPath)
 		}
-		err = os.RemoveAll(rpPath)
-		if err != nil {
+		if err := removeJunctionSafe(rpPath); err != nil {
 			return burrito.WrapErrorf(
 				err, "Failed to clear resource pack from build path %q.\n"+
 					"Are user permissions correct?", rpPath)

--- a/regolith/file_protection.go
+++ b/regolith/file_protection.go
@@ -109,6 +109,12 @@ func NewEditedFiles() EditedFiles {
 // listFiles returns a slice of strings with paths to all the files
 // starting from "path"
 func listFiles(path string) ([]string, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return make([]string, 0), nil
+		}
+		return nil, burrito.WrapErrorf(err, osStatErrorAny, path)
+	}
 	// 150 is just an arbitrary number I chose to avoid constant memory
 	// allocation while expanding the slice capacity
 	result := make([]string, 0, 150)

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -881,27 +881,41 @@ func (c *syncMetadataCache) invalidate(path string) {
 	c.m.Delete(path)
 }
 
+// removeJunctionSafe removes a path that might be a junction/symlink.
+// For junctions/symlinks it uses os.Remove (won't follow into target).
+// For real directories it uses os.RemoveAll.
+// Returns nil if the path doesn't exist.
+func removeJunctionSafe(path string) error {
+	linfo, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return burrito.WrapErrorf(err, osStatErrorAny, path)
+	}
+	if linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
+		return os.Remove(path)
+	}
+	if linfo.IsDir() {
+		return os.RemoveAll(path)
+	}
+	return os.Remove(path)
+}
+
 func syncLink(srcPath, dstPath string) error {
 	linkTarget, err := os.Readlink(srcPath)
 	if err != nil {
 		Logger.Debugf("SYNC: Skipping irregular file %s", srcPath)
 		return nil
 	}
-	if linfo, lerr := os.Lstat(dstPath); lerr == nil {
-		if linfo.IsDir() && linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) == 0 {
-			if err := os.RemoveAll(dstPath); err != nil {
-				return burrito.WrapErrorf(err, osRemoveError, dstPath)
-			}
-		} else {
-			if err := os.Remove(dstPath); err != nil {
-				return burrito.WrapErrorf(err, osRemoveError, dstPath)
-			}
-		}
-	} else if !os.IsNotExist(lerr) {
-		return burrito.WrapErrorf(lerr, osStatErrorAny, dstPath)
+	if err := removeJunctionSafe(dstPath); err != nil {
+		return burrito.WrapErrorf(err, osRemoveError, dstPath)
 	}
-	targetInfo, err := os.Stat(srcPath)
-	if err == nil && targetInfo.IsDir() {
+	srcLinfo, lerr := os.Lstat(srcPath)
+	isJunction := lerr == nil && srcLinfo.Mode()&fs.ModeIrregular != 0
+	targetInfo, serr := os.Stat(srcPath)
+	isDirLink := isJunction || (serr == nil && targetInfo.IsDir())
+	if isDirLink {
 		err = createDirLink(dstPath, linkTarget)
 	} else {
 		err = os.Symlink(linkTarget, dstPath)
@@ -937,6 +951,10 @@ func SyncDirectories(
 			return
 		}
 		if cache.get(dstDir) == nil {
+			if err := removeJunctionSafe(dstDir); err != nil {
+				syncErr = burrito.WrapErrorf(err, osRemoveError, dstDir)
+				return
+			}
 			if err := os.MkdirAll(dstDir, 0755); err != nil {
 				syncErr = burrito.WrapErrorf(err, osMkdirError, dstDir)
 				return
@@ -970,13 +988,15 @@ func SyncDirectories(
 			if srcMeta != nil && srcMeta.IsDir() {
 				dstMeta := cache.get(dstPath)
 				if dstMeta != nil && !dstMeta.IsDir() {
-					if err := os.Remove(dstPath); err != nil {
+					// Destination is a file but source is a dir — remove it
+					if err := removeJunctionSafe(dstPath); err != nil {
 						syncErr = burrito.WrapErrorf(err, osRemoveError, dstPath)
 						return
 					}
 					cache.invalidate(dstPath)
-				}
-				if dstMeta != nil && dstMeta.IsDir() {
+				} else if dstMeta != nil {
+					// Destination looks like a dir via os.Stat — check if it's
+					// actually a junction and remove just the junction
 					linfo, lerr := os.Lstat(dstPath)
 					if lerr != nil {
 						syncErr = burrito.WrapErrorf(lerr, osStatErrorAny, dstPath)
@@ -1000,18 +1020,8 @@ func SyncDirectories(
 				}
 				dstMeta := cache.get(dstPath)
 				if dstMeta != nil && dstMeta.IsDir() {
-					linfo, lerr := os.Lstat(dstPath)
-					if lerr != nil {
-						return burrito.WrapErrorf(lerr, osStatErrorAny, dstPath)
-					}
-					if linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
-						if err := os.Remove(dstPath); err != nil {
-							return burrito.WrapErrorf(err, osRemoveError, dstPath)
-						}
-					} else {
-						if err := os.RemoveAll(dstPath); err != nil {
-							return burrito.WrapErrorf(err, osRemoveError, dstPath)
-						}
+					if err := removeJunctionSafe(dstPath); err != nil {
+						return burrito.WrapErrorf(err, osRemoveError, dstPath)
 					}
 					dstMeta = nil
 				}
@@ -1036,6 +1046,20 @@ func SyncDirectories(
 				}
 				return nil
 			})
+		}
+	}
+
+	// If the destination is a junction (from symlink_export), ensure its target
+	// directory exists so os.Stat follows it successfully and we don't replace
+	// the junction with a real directory.
+	if linfo, lerr := os.Lstat(destination); lerr == nil {
+		if linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
+			if target, err := os.Readlink(destination); err == nil {
+				if !filepath.IsAbs(target) {
+					target = filepath.Join(filepath.Dir(destination), target)
+				}
+				os.MkdirAll(target, 0755)
+			}
 		}
 	}
 
@@ -1080,10 +1104,7 @@ func SyncDirectories(
 						return ctx2.Err()
 					}
 					Logger.Debugf("SYNC: Removing %s", dstPath)
-					if isLink || !isDir {
-						return os.Remove(dstPath)
-					}
-					return os.RemoveAll(dstPath)
+					return removeJunctionSafe(dstPath)
 				})
 			} else if isDir && !isLink {
 				cleanupDir(srcPath, dstPath)

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -887,8 +887,18 @@ func syncLink(srcPath, dstPath string) error {
 		Logger.Debugf("SYNC: Skipping irregular file %s", srcPath)
 		return nil
 	}
-	if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
-		return burrito.WrapErrorf(err, osRemoveError, dstPath)
+	if linfo, lerr := os.Lstat(dstPath); lerr == nil {
+		if linfo.IsDir() && linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) == 0 {
+			if err := os.RemoveAll(dstPath); err != nil {
+				return burrito.WrapErrorf(err, osRemoveError, dstPath)
+			}
+		} else {
+			if err := os.Remove(dstPath); err != nil {
+				return burrito.WrapErrorf(err, osRemoveError, dstPath)
+			}
+		}
+	} else if !os.IsNotExist(lerr) {
+		return burrito.WrapErrorf(lerr, osStatErrorAny, dstPath)
 	}
 	targetInfo, err := os.Stat(srcPath)
 	if err == nil && targetInfo.IsDir() {
@@ -964,6 +974,7 @@ func SyncDirectories(
 						syncErr = burrito.WrapErrorf(err, osRemoveError, dstPath)
 						return
 					}
+					cache.invalidate(dstPath)
 				}
 				if dstMeta != nil && dstMeta.IsDir() {
 					linfo, lerr := os.Lstat(dstPath)
@@ -976,6 +987,7 @@ func SyncDirectories(
 							syncErr = burrito.WrapErrorf(err, osRemoveError, dstPath)
 							return
 						}
+						cache.invalidate(dstPath)
 					}
 				}
 				syncDir(srcPath, dstPath)

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -2,16 +2,20 @@ package regolith
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/otiai10/copy"
 )
@@ -851,107 +855,245 @@ func MoveOrCopy(
 // SyncDirectories copies the source to destination while checking size and modification time.
 // If the file in the destination is different than the one in the source, it's overwritten,
 // otherwise it's skipped (the destination file is not modified).
+
+type syncMetadataCache struct {
+	m sync.Map
+}
+
+type cachedMeta struct {
+	info os.FileInfo
+}
+
+func (c *syncMetadataCache) get(path string) os.FileInfo {
+	if v, ok := c.m.Load(path); ok {
+		return v.(*cachedMeta).info
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		c.m.Store(path, &cachedMeta{info: nil})
+		return nil
+	}
+	c.m.Store(path, &cachedMeta{info: info})
+	return info
+}
+
+func (c *syncMetadataCache) invalidate(path string) {
+	c.m.Delete(path)
+}
+
+func syncLink(srcPath, dstPath string) error {
+	linkTarget, err := os.Readlink(srcPath)
+	if err != nil {
+		Logger.Debugf("SYNC: Skipping irregular file %s", srcPath)
+		return nil
+	}
+	if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
+		return burrito.WrapErrorf(err, osRemoveError, dstPath)
+	}
+	targetInfo, err := os.Stat(srcPath)
+	if err == nil && targetInfo.IsDir() {
+		err = createDirLink(dstPath, linkTarget)
+	} else {
+		err = os.Symlink(linkTarget, dstPath)
+	}
+	if err != nil {
+		return burrito.WrapErrorf(err, createDirLinkError, dstPath, linkTarget)
+	}
+	return nil
+}
+
 func SyncDirectories(
 	source string, destination string, makeReadOnly bool,
 ) error {
-	// Make destination parent if not exists
 	destinationParent := filepath.Dir(destination)
 	if err := os.MkdirAll(destinationParent, 0755); err != nil {
 		return burrito.WrapErrorf(err, osMkdirError, destinationParent)
 	}
-	err := filepath.WalkDir(source, func(srcPath string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		relPath, err := filepath.Rel(source, srcPath)
-		if err != nil {
-			return burrito.WrapErrorf(err, filepathRelError, source, srcPath)
-		}
-		destPath := filepath.Join(destination, relPath)
 
-		destInfo, err := os.Stat(destPath)
-		if err != nil && !os.IsNotExist(err) {
-			return burrito.WrapErrorf(err, osStatErrorAny, destPath)
+	cache := &syncMetadataCache{}
+	maxWorkers := runtime.GOMAXPROCS(0)
+	if maxWorkers < 4 {
+		maxWorkers = 4
+	}
+
+	// Phase 1: Sync source -> destination (parallel file I/O, sequential traversal)
+	g, ctx := errgroup.WithContext(context.Background())
+	g.SetLimit(maxWorkers)
+
+	var syncErr error
+	var syncDir func(srcDir, dstDir string)
+	syncDir = func(srcDir, dstDir string) {
+		if syncErr != nil {
+			return
 		}
-		info, ierr := d.Info()
-		if ierr != nil {
-			return ierr
-		}
-		if (err != nil && os.IsNotExist(err)) || info.ModTime() != destInfo.ModTime() || info.Size() != destInfo.Size() {
-			if d.IsDir() {
-				return os.MkdirAll(destPath, info.Mode())
+		if cache.get(dstDir) == nil {
+			if err := os.MkdirAll(dstDir, 0755); err != nil {
+				syncErr = burrito.WrapErrorf(err, osMkdirError, dstDir)
+				return
 			}
-			Logger.Debugf("SYNC: Copying file %s to %s", srcPath, destPath)
-			// If file exists, we need to remove it first to avoid permission issues when it's
-			// read-only
-			if destInfo != nil {
-				err = os.Remove(destPath)
-				if err != nil {
-					return burrito.WrapErrorf(err, osRemoveError, destPath)
+		}
+
+		entries, err := os.ReadDir(srcDir)
+		if err != nil {
+			syncErr = burrito.WrapErrorf(err, osReadDirError, srcDir)
+			return
+		}
+
+		for _, entry := range entries {
+			if syncErr != nil || ctx.Err() != nil {
+				return
+			}
+			srcPath := filepath.Join(srcDir, entry.Name())
+			dstPath := filepath.Join(dstDir, entry.Name())
+
+			if entry.Type()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
+				g.Go(func() error {
+					if ctx.Err() != nil {
+						return ctx.Err()
+					}
+					return syncLink(srcPath, dstPath)
+				})
+				continue
+			}
+
+			srcMeta := cache.get(srcPath)
+			if srcMeta != nil && srcMeta.IsDir() {
+				dstMeta := cache.get(dstPath)
+				if dstMeta != nil && !dstMeta.IsDir() {
+					if err := os.Remove(dstPath); err != nil {
+						syncErr = burrito.WrapErrorf(err, osRemoveError, dstPath)
+						return
+					}
 				}
+				if dstMeta != nil && dstMeta.IsDir() {
+					linfo, lerr := os.Lstat(dstPath)
+					if lerr != nil {
+						syncErr = burrito.WrapErrorf(lerr, osStatErrorAny, dstPath)
+						return
+					}
+					if linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
+						if err := os.Remove(dstPath); err != nil {
+							syncErr = burrito.WrapErrorf(err, osRemoveError, dstPath)
+							return
+						}
+					}
+				}
+				syncDir(srcPath, dstPath)
+				continue
 			}
-			return CopyFile(srcPath, destPath)
-		} else {
-			Logger.Debugf("SYNC: Skipping file %s", srcPath)
+
+			g.Go(func() error {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				dstMeta := cache.get(dstPath)
+				if dstMeta != nil && dstMeta.IsDir() {
+					linfo, lerr := os.Lstat(dstPath)
+					if lerr != nil {
+						return burrito.WrapErrorf(lerr, osStatErrorAny, dstPath)
+					}
+					if linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
+						if err := os.Remove(dstPath); err != nil {
+							return burrito.WrapErrorf(err, osRemoveError, dstPath)
+						}
+					} else {
+						if err := os.RemoveAll(dstPath); err != nil {
+							return burrito.WrapErrorf(err, osRemoveError, dstPath)
+						}
+					}
+					dstMeta = nil
+				}
+				needsCopy := dstMeta == nil || srcMeta == nil ||
+					srcMeta.Size() != dstMeta.Size() ||
+					!srcMeta.ModTime().Equal(dstMeta.ModTime())
+				if !needsCopy {
+					return nil
+				}
+				Logger.Debugf("SYNC: Copying file %s to %s", srcPath, dstPath)
+				if dstMeta != nil {
+					if err := os.Remove(dstPath); err != nil {
+						return burrito.WrapErrorf(err, osRemoveError, dstPath)
+					}
+				}
+				if err := CopyFile(srcPath, dstPath); err != nil {
+					return err
+				}
+				cache.invalidate(dstPath)
+				if makeReadOnly {
+					os.Chmod(dstPath, 0444)
+				}
+				return nil
+			})
 		}
-		return nil
-	})
-	if err != nil {
-		return burrito.WrapErrorf(err, osCopyError, source, destination)
 	}
 
-	// A simple linked list implementation
-	type Node struct {
-		next  *Node
-		value string
+	syncDir(source, destination)
+	waitErr := g.Wait()
+	if syncErr != nil {
+		return burrito.WrapErrorf(syncErr, osCopyError, source, destination)
 	}
-	// Remove files/folders in destination that are not in source
-	var root = &Node{
-		next:  nil,
-		value: "",
+	if waitErr != nil {
+		return burrito.WrapErrorf(waitErr, osCopyError, source, destination)
 	}
-	err = filepath.WalkDir(destination, func(destPath string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+
+	// Phase 2: Cleanup destination — remove files not in source (parallel)
+	g2, ctx2 := errgroup.WithContext(context.Background())
+	g2.SetLimit(maxWorkers)
+
+	var cleanupErr error
+	var cleanupDir func(srcDir, dstDir string)
+	cleanupDir = func(srcDir, dstDir string) {
+		if cleanupErr != nil {
+			return
 		}
-		relPath, err := filepath.Rel(destination, destPath)
+		entries, err := os.ReadDir(dstDir)
 		if err != nil {
-			return burrito.WrapErrorf(err, filepathRelError, destination, destPath)
+			cleanupErr = burrito.WrapErrorf(err, osReadDirError, dstDir)
+			return
 		}
-		srcPath := filepath.Join(source, relPath)
-		if _, err := os.Stat(srcPath); os.IsNotExist(err) {
-			Logger.Debugf("SYNC: Removing file %s", destPath)
-			next := &Node{
-				next:  root,
-				value: destPath,
+
+		for _, entry := range entries {
+			if cleanupErr != nil || ctx2.Err() != nil {
+				return
 			}
-			root = next
-		}
-		return nil
-	})
+			srcPath := filepath.Join(srcDir, entry.Name())
+			dstPath := filepath.Join(dstDir, entry.Name())
 
-	if err != nil {
-		return burrito.PassError(err)
+			isLink := entry.Type()&(fs.ModeSymlink|fs.ModeIrregular) != 0
+			isDir := entry.IsDir()
+
+			if cache.get(srcPath) == nil {
+				g2.Go(func() error {
+					if ctx2.Err() != nil {
+						return ctx2.Err()
+					}
+					Logger.Debugf("SYNC: Removing %s", dstPath)
+					if isLink || !isDir {
+						return os.Remove(dstPath)
+					}
+					return os.RemoveAll(dstPath)
+				})
+			} else if isDir && !isLink {
+				cleanupDir(srcPath, dstPath)
+			}
+		}
 	}
 
-	for root.next != nil {
-		err = os.RemoveAll(root.value)
-		if err != nil {
-			return burrito.WrapErrorf(err, osRemoveError, root.value)
-		}
-		root = root.next
+	cleanupDir(source, destination)
+	cleanupWaitErr := g2.Wait()
+	if cleanupErr != nil {
+		return burrito.PassError(cleanupErr)
+	}
+	if cleanupWaitErr != nil {
+		return burrito.PassError(cleanupWaitErr)
 	}
 
-	// Make files read only if this option is selected
 	if makeReadOnly {
 		Logger.Infof("Changing the access for output path to "+
 			"read-only.\n\tPath: %s", destination)
 		err := filepath.WalkDir(destination,
 			func(s string, d fs.DirEntry, e error) error {
-
 				if e != nil {
-					// Error message isn't important as it's not passed further
-					// in the code
 					return e
 				}
 				if !d.IsDir() {
@@ -962,8 +1104,7 @@ func SyncDirectories(
 		if err != nil {
 			Logger.Warnf(
 				"Failed to change access of the output path to read-only.\n"+
-					"\tPath: %s",
-				destination)
+					"\tPath: %s", destination)
 		}
 	}
 	return nil

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -896,12 +896,24 @@ func removeJunctionSafe(path string) error {
 		return burrito.WrapErrorf(err, osStatErrorAny, path)
 	}
 	if linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
-		return os.Remove(path)
+		if err := os.Remove(path); err != nil {
+			return burrito.WrapErrorf(err,
+				"Failed to remove junction/symlink.\nPath: %s", path)
+		}
+		return nil
 	}
 	if linfo.IsDir() {
-		return os.RemoveAll(path)
+		if err := os.RemoveAll(path); err != nil {
+			return burrito.WrapErrorf(err,
+				"Failed to remove directory.\nPath: %s", path)
+		}
+		return nil
 	}
-	return os.Remove(path)
+	if err := os.Remove(path); err != nil {
+		return burrito.WrapErrorf(err,
+			"Failed to remove file.\nPath: %s", path)
+	}
+	return nil
 }
 
 // syncLink copies a symlink or junction from srcPath to make the dstPath
@@ -915,7 +927,7 @@ func syncLink(srcPath, dstPath string) error {
 		return nil
 	}
 	if err := removeJunctionSafe(dstPath); err != nil {
-		return burrito.WrapErrorf(err, osRemoveError, dstPath)
+		return burrito.PassError(err)
 	}
 	srcLinfo, lerr := os.Lstat(srcPath)
 	isJunction := lerr == nil && srcLinfo.Mode()&fs.ModeIrregular != 0
@@ -961,7 +973,7 @@ func SyncDirectories(
 		}
 		if cache.get(dstDir) == nil {
 			if err := removeJunctionSafe(dstDir); err != nil {
-				syncErr = burrito.WrapErrorf(err, osRemoveError, dstDir)
+				syncErr = burrito.PassError(err)
 				return
 			}
 			if err := os.MkdirAll(dstDir, 0755); err != nil {
@@ -1001,7 +1013,7 @@ func SyncDirectories(
 				if dstMeta != nil && !dstMeta.IsDir() {
 					// Destination is a file but source is a dir — remove it
 					if err := removeJunctionSafe(dstPath); err != nil {
-						syncErr = burrito.WrapErrorf(err, osRemoveError, dstPath)
+						syncErr = burrito.PassError(err)
 						return
 					}
 					cache.invalidate(dstPath)
@@ -1033,7 +1045,7 @@ func SyncDirectories(
 				dstMeta := cache.get(dstPath)
 				if dstMeta != nil && dstMeta.IsDir() {
 					if err := removeJunctionSafe(dstPath); err != nil {
-						return burrito.WrapErrorf(err, osRemoveError, dstPath)
+						return burrito.PassError(err)
 					}
 					dstMeta = nil
 				}

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -852,10 +852,6 @@ func MoveOrCopy(
 	return nil
 }
 
-// SyncDirectories copies the source to destination while checking size and modification time.
-// If the file in the destination is different than the one in the source, it's overwritten,
-// otherwise it's skipped (the destination file is not modified).
-
 type syncMetadataCache struct {
 	m sync.Map
 }
@@ -926,6 +922,9 @@ func syncLink(srcPath, dstPath string) error {
 	return nil
 }
 
+// SyncDirectories copies the source to destination while checking size and modification time.
+// If the file in the destination is different than the one in the source, it's overwritten,
+// otherwise it's skipped (the destination file is not modified).
 func SyncDirectories(
 	source string, destination string, makeReadOnly bool,
 ) error {

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -852,10 +852,16 @@ func MoveOrCopy(
 	return nil
 }
 
+// syncMetadataCache is a thread-safe cache for file FileInfo used in
+// SyncDirectories to reduce the number of os.Stat calls.
 type syncMetadataCache struct {
 	m sync.Map
 }
 
+// cachedMeta is a wrapper for os.FileInfo used in syncMetadataCache. The
+// 'nil' value of the 'info' field indicates that the path was previously
+// checked but os.Stat returned an error (file not found or permission denied).
+// The errors aren't cached.
 type cachedMeta struct {
 	info os.FileInfo
 }
@@ -898,6 +904,10 @@ func removeJunctionSafe(path string) error {
 	return os.Remove(path)
 }
 
+// syncLink copies a symlink or junction from srcPath to make the dstPath
+// point to the same target. If srcPath is not a symlink or junction,
+// it's skipped without an error. If dstPath already exists, it's removed
+// first.
 func syncLink(srcPath, dstPath string) error {
 	linkTarget, err := os.Readlink(srcPath)
 	if err != nil {
@@ -973,6 +983,7 @@ func SyncDirectories(
 			srcPath := filepath.Join(srcDir, entry.Name())
 			dstPath := filepath.Join(dstDir, entry.Name())
 
+			// Symlink source
 			if entry.Type()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
 				g.Go(func() error {
 					if ctx.Err() != nil {
@@ -983,6 +994,7 @@ func SyncDirectories(
 				continue
 			}
 
+			// Directory source
 			srcMeta := cache.get(srcPath)
 			if srcMeta != nil && srcMeta.IsDir() {
 				dstMeta := cache.get(dstPath)
@@ -1013,6 +1025,7 @@ func SyncDirectories(
 				continue
 			}
 
+			// File source
 			g.Go(func() error {
 				if ctx.Err() != nil {
 					return ctx.Err()

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -30,6 +30,7 @@ type RunContext struct {
 	DotRegolithPath  string
 	Settings         map[string]any
 	ExtraArguments   []string
+	UnsafeMode       bool
 
 	// interruption is a channel used to receive notifications about changes
 	// in the source files, in order to trigger a restart of the program in

--- a/regolith/filter_profile.go
+++ b/regolith/filter_profile.go
@@ -17,6 +17,7 @@ func (f *ProfileFilter) Run(context RunContext) (bool, error) {
 		interruption:     context.interruption,
 		DotRegolithPath:  context.DotRegolithPath,
 		Settings:         f.Settings,
+		UnsafeMode:       context.UnsafeMode,
 	})
 }
 

--- a/regolith/filter_remote.go
+++ b/regolith/filter_remote.go
@@ -98,6 +98,7 @@ func (f *RemoteFilter) run(context RunContext) (bool, error) {
 			Parent:           context.Parent,
 			DotRegolithPath:  context.DotRegolithPath,
 			Settings:         filter.GetSettings(),
+			UnsafeMode:       context.UnsafeMode,
 		}
 		// Disabled filters are skipped
 		disabled, err := filter.IsDisabled(runContext)

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -217,7 +217,7 @@ func InstallAll(force, update, debug, refreshFilters bool, env string) error {
 
 // prepareRunContext prepares the context for the "regolith run" and
 // "regolith watch" commands.
-func prepareRunContext(profileName string, extraFilterArgs []string, debug bool, env string) (*RunContext, error) {
+func prepareRunContext(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool) (*RunContext, error) {
 	InitLogging(debug)
 	if err := loadEnvFileFromArg(env); err != nil {
 		return nil, burrito.WrapErrorf(err, loadEnvFileFromArgError, env)
@@ -264,14 +264,15 @@ func prepareRunContext(profileName string, extraFilterArgs []string, debug bool,
 		DotRegolithPath:  dotRegolithPath,
 		Settings:         map[string]any{},
 		ExtraArguments:   extraFilterArgs,
+		UnsafeMode:       unsafeMode,
 	}, nil
 }
 
 // Run handles the "regolith run" command. It runs selected profile and exports
 // created resource pack and behavior pack to the target destination.
-func Run(profileName string, extraFilterArgs []string, debug bool, env string) error {
+func Run(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool) error {
 	// Get the context
-	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env)
+	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env, unsafeMode)
 	defer ShutdownLogging()
 	if err != nil {
 		return burrito.PassError(err)
@@ -294,9 +295,9 @@ func Run(profileName string, extraFilterArgs []string, debug bool, env string) e
 // Watch handles the "regolith watch" command. It watches the project
 // directories, and it runs selected profile and exports created resource pack
 // and behavior pack to the target destination when the project changes.
-func Watch(profileName string, extraFilterArgs []string, debug bool, env string) error {
+func Watch(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool) error {
 	// Get the context
-	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env)
+	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env, unsafeMode)
 	defer ShutdownLogging()
 	if err != nil {
 		return burrito.PassError(err)

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -3,7 +3,6 @@ package regolith
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -176,21 +175,8 @@ func SetupTmpFiles(context RunContext) error {
 		}
 	} else if shouldCreateSymlinks {
 		for _, tmpPath := range []string{bpTmpPath, rpTmpPath} {
-			linfo, err := os.Lstat(tmpPath)
-			if err != nil {
-				if os.IsNotExist(err) {
-					continue
-				}
-				return burrito.WrapErrorf(err, osStatErrorAny, tmpPath)
-			}
-			if linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
-				if err := os.Remove(tmpPath); err != nil {
-					return burrito.WrapErrorf(err, osRemoveError, tmpPath)
-				}
-			} else {
-				if err := os.RemoveAll(tmpPath); err != nil {
-					return burrito.WrapErrorf(err, osRemoveError, tmpPath)
-				}
+			if err := removeJunctionSafe(tmpPath); err != nil {
+				return burrito.WrapErrorf(err, osRemoveError, tmpPath)
 			}
 		}
 	}

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -3,6 +3,7 @@ package regolith
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -167,11 +168,30 @@ func SetupTmpFiles(context RunContext) error {
 
 	// Clean the temporary directory
 	isRegularRun := !useSizeTimeCheck && !useSymlinkExport
-	if isRegularRun || shouldCreateSymlinks {
+	if isRegularRun {
 		Logger.Debugf("Cleaning \"%s\"", absTmpPath)
 		err := os.RemoveAll(absTmpPath)
 		if err != nil {
 			return burrito.WrapErrorf(err, osRemoveError, absTmpPath)
+		}
+	} else if shouldCreateSymlinks {
+		for _, tmpPath := range []string{bpTmpPath, rpTmpPath} {
+			linfo, err := os.Lstat(tmpPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return burrito.WrapErrorf(err, osStatErrorAny, tmpPath)
+			}
+			if linfo.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
+				if err := os.Remove(tmpPath); err != nil {
+					return burrito.WrapErrorf(err, osRemoveError, tmpPath)
+				}
+			} else {
+				if err := os.RemoveAll(tmpPath); err != nil {
+					return burrito.WrapErrorf(err, osRemoveError, tmpPath)
+				}
+			}
 		}
 	}
 
@@ -183,25 +203,23 @@ func SetupTmpFiles(context RunContext) error {
 
 	// Create symlinks
 	if shouldCreateSymlinks {
-		// Check deletion safety
-		editedFiles := LoadEditedFiles(dotRegolithPath)
-		err := editedFiles.CheckDeletionSafety(rpExportPath, bpExportPath)
-		if err != nil {
-			return burrito.WrapErrorf(
-				err,
-				checkDeletionSafetyError,
-				rpExportPath, bpExportPath)
+		if !UnsafeMode {
+			editedFiles := LoadEditedFiles(dotRegolithPath)
+			err := editedFiles.CheckDeletionSafety(rpExportPath, bpExportPath)
+			if err != nil {
+				return burrito.WrapErrorf(
+					err,
+					checkDeletionSafetyError,
+					rpExportPath, bpExportPath)
+			}
+		}
+		if err := os.MkdirAll(bpExportPath, 0755); err != nil {
+			return burrito.WrapErrorf(err, osMkdirError, bpExportPath)
+		}
+		if err := os.MkdirAll(rpExportPath, 0755); err != nil {
+			return burrito.WrapErrorf(err, osMkdirError, rpExportPath)
 		}
 
-		// Remove existing exported paths
-		if err := os.RemoveAll(bpExportPath); err != nil {
-			return burrito.WrapErrorf(err, osRemoveError, bpExportPath)
-		}
-		if err := os.RemoveAll(rpExportPath); err != nil {
-			return burrito.WrapErrorf(err, osRemoveError, rpExportPath)
-		}
-
-		// Create symlinks
 		if err := createDirLink(filepath.Join(absTmpPath, "BP"), bpExportPath); err != nil {
 			return burrito.WrapErrorf(err, createDirLinkError, filepath.Join(absTmpPath, "BP"), bpExportPath)
 		}
@@ -292,9 +310,7 @@ func SetupTmpFiles(context RunContext) error {
 		editedFiles := NewEditedFiles()
 		err = editedFiles.UpdateFromPaths(rpExportPath, bpExportPath)
 		if err != nil {
-			return burrito.WrapError(
-				err,
-				"Failed to create a list of files safe to edit")
+			return burrito.WrapError(err, updatedFilesUpdateError)
 		}
 		err = editedFiles.Dump(dotRegolithPath)
 		if err != nil {

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -176,7 +176,7 @@ func SetupTmpFiles(context RunContext) error {
 	} else if shouldCreateSymlinks {
 		for _, tmpPath := range []string{bpTmpPath, rpTmpPath} {
 			if err := removeJunctionSafe(tmpPath); err != nil {
-				return burrito.WrapErrorf(err, osRemoveError, tmpPath)
+				return burrito.PassError(err)
 			}
 		}
 	}
@@ -189,7 +189,7 @@ func SetupTmpFiles(context RunContext) error {
 
 	// Create symlinks
 	if shouldCreateSymlinks {
-		if !UnsafeMode {
+		if !context.UnsafeMode {
 			editedFiles := LoadEditedFiles(dotRegolithPath)
 			err := editedFiles.CheckDeletionSafety(rpExportPath, bpExportPath)
 			if err != nil {

--- a/regolith/utils.go
+++ b/regolith/utils.go
@@ -494,7 +494,7 @@ func SliceAny[T any](slice []T, predicate func(T) bool) bool {
 
 func isSymlinkTo(path, target string) bool {
 	info, err := os.Lstat(path)
-	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+	if err != nil || info.Mode()&(os.ModeSymlink|os.ModeIrregular) == 0 {
 		return false
 	}
 	dest, err := os.Readlink(path)
@@ -511,7 +511,7 @@ func isSymlinkTo(path, target string) bool {
 
 func isSymlink(path string) bool {
 	info, err := os.Lstat(path)
-	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+	if err != nil || info.Mode()&(os.ModeSymlink|os.ModeIrregular) == 0 {
 		return false
 	}
 	return true

--- a/test/conditional_filters_test.go
+++ b/test/conditional_filters_test.go
@@ -29,7 +29,7 @@ func TestConditionalFilter(t *testing.T) {
 
 	// THE TEST
 	t.Log("Running Regolith with a conditional filter...")
-	if err := regolith.Run("default", []string{}, true, ""); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/custom_pack_name_test.go
+++ b/test/custom_pack_name_test.go
@@ -30,7 +30,7 @@ func TestCustomPackName(t *testing.T) {
 
 	// THE TEST
 	t.Log("Running Regolith with a conditional filter...")
-	if err := regolith.Run("default", []string{}, true, ""); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/development_export_windows_test.go
+++ b/test/development_export_windows_test.go
@@ -103,7 +103,7 @@ func _testCustomDevelopmentExportLocation(
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run(profileToRun, []string{}, true, "")
+	err = regolith.Run(profileToRun, []string{}, true, "", false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/file_protection_test.go
+++ b/test/file_protection_test.go
@@ -34,18 +34,18 @@ func TestSwitchingExportTargets(t *testing.T) {
 	// Run Regolith with targets: A, B, A
 	t.Log("Testing the 'regolith run' with changing export targets...")
 	t.Log("Running Regolith with target A...")
-	err := regolith.Run("exact_export_A", []string{}, true, "")
+	err := regolith.Run("exact_export_A", []string{}, true, "", false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on first attempt to export to A:", err)
 	}
 	t.Log("Running Regolith with target B...")
-	err = regolith.Run("exact_export_B", []string{}, true, "")
+	err = regolith.Run("exact_export_B", []string{}, true, "", false)
 	if err != nil {
 		t.Fatal("Unable RunProfile failed on attempt to export to B:", err)
 	}
 	t.Log("Running Regolith with target A (2nd time)...")
-	err = regolith.Run("exact_export_A", []string{}, true, "")
+	err = regolith.Run("exact_export_A", []string{}, true, "", false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on second attempt to export to A:", err)
@@ -78,7 +78,7 @@ func TestTriggerFileProtection(t *testing.T) {
 	// 1. Run Regolith (export to A)
 	t.Log("Testing the 'regolith run' with file protection...")
 	t.Log("Running Regolith...")
-	err := regolith.Run("exact_export_A", []string{}, true, "")
+	err := regolith.Run("exact_export_A", []string{}, true, "", false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on first attempt to export to A:", err)
@@ -94,7 +94,7 @@ func TestTriggerFileProtection(t *testing.T) {
 
 	// 3. Run Regolith (export to A), expect failure.
 	t.Log("Running Regolith (this should be stopped by file protection system)...")
-	err = regolith.Run("exact_export_A", []string{}, true, "")
+	err = regolith.Run("exact_export_A", []string{}, true, "", false)
 	if err == nil {
 		t.Fatal("Expected RunProfile to fail on second attempt to export to A")
 	}

--- a/test/filter_async_test.go
+++ b/test/filter_async_test.go
@@ -30,7 +30,7 @@ func TestAsyncFilter(t *testing.T) {
 	t.Log("Running Regolith with a conditional filter...")
 
 	start := time.Now()
-	if err := regolith.Run("default", []string{}, true, ""); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	duration := time.Since(start)

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -44,7 +44,7 @@ func TestRegolithRunMissingRp(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	// THE TEST
-	err := regolith.Run("dev", []string{}, true, "")
+	err := regolith.Run("dev", []string{}, true, "", false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}
@@ -71,7 +71,7 @@ func TestLocalRequirementsInstallAndRun(t *testing.T) {
 		t.Fatal("'regolith install-all' failed", err.Error())
 	}
 	t.Log("Testing the 'regolith run' command...")
-	if err := regolith.Run("dev", []string{}, true, ""); err != nil {
+	if err := regolith.Run("dev", []string{}, true, "", false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 }
@@ -95,7 +95,7 @@ func TestExeFilterRun(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	if err := regolith.Run("dev", []string{}, true, ""); err != nil {
+	if err := regolith.Run("dev", []string{}, true, "", false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	// TEST EVALUATION
@@ -125,7 +125,7 @@ func TestProfileFilterRun(t *testing.T) {
 	// THE TEST
 	// Invalid profile (shoud fail)
 	t.Log("Running invalid profile filter with circular dependencies (this should fail).")
-	err := regolith.Run("invalid_circular_profile_1", []string{}, true, "")
+	err := regolith.Run("invalid_circular_profile_1", []string{}, true, "", false)
 	if err == nil {
 		t.Fatal("'regolith run' didn't return an error after running" +
 			" a circular profile filter.")
@@ -134,7 +134,7 @@ func TestProfileFilterRun(t *testing.T) {
 	}
 	// Valid profile (should succeed)
 	t.Log("Running valid profile filter.")
-	err = regolith.Run("correct_nested_profile", []string{}, true, "")
+	err = regolith.Run("correct_nested_profile", []string{}, true, "", false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}

--- a/test/pre_post_shell_os_specific_test.go
+++ b/test/pre_post_shell_os_specific_test.go
@@ -27,7 +27,7 @@ func TestPrePostShellCommandsOSSpecific(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing OS-specific preShell and postShell commands...")
-	if err := regolith.Run("default", nil, true, ""); err != nil {
+	if err := regolith.Run("default", nil, true, "", false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/pre_post_shell_test.go
+++ b/test/pre_post_shell_test.go
@@ -27,7 +27,7 @@ func TestPrePostShellCommands(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command with preShell and postShell...")
-	if err := regolith.Run("default", nil, true, ""); err != nil {
+	if err := regolith.Run("default", nil, true, "", false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -38,7 +38,7 @@ func TestInstallAllAndRun(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("dev", []string{}, true, "")
+	err = regolith.Run("dev", []string{}, true, "", false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}
@@ -78,7 +78,7 @@ func TestDataModifyRemoteFilter(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("default", []string{}, true, "")
+	err = regolith.Run("default", []string{}, true, "", false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/size_time_check_optimization_method_test.go
+++ b/test/size_time_check_optimization_method_test.go
@@ -51,7 +51,7 @@ func TestSizeTimeCheckOptimizationCorectness(t *testing.T) {
 	// Run the project
 	t.Log("Running Regolith...")
 
-	if err := regolith.Run("default", []string{}, true, ""); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	// TEST EVALUATION
@@ -94,7 +94,7 @@ func TestSizeTimeCheckOptimizationSpeed(t *testing.T) {
 
 		// Start the timer
 		start := time.Now()
-		if err := regolith.Run("default", []string{}, true, ""); err != nil {
+		if err := regolith.Run("default", []string{}, true, "", false); err != nil {
 			t.Fatal("'regolith run' failed:", err.Error())
 		}
 		// Stop the timer


### PR DESCRIPTION
- Adds the --unsafe flag 

- Fixes an error that was thrown when using `--experiments size_time_check,symlink_export` in my projects
```
[ERROR] Failed to run profile ""
[+]: Failed to setup temporary files.
  >> Regolith files path: .regolith
[+]: Failed to setup data folder in the temporary directory.
[+]: Failed to export behavior pack.
[+]: Failed to copy file or directory:
  >> Source: ./packs/data
  >> Target: <redacted>\.regolith\tmp\data
[+]: Failed to write to file.
  >> Path: <redacted>\.regolith\tmp\data\scripts\node_modules\<redacted>
[+]: read packs\data\scripts\node_modules\<redacted>: Incorrect function.
```

- Parellises I/O in SyncDirectories