### PR TITLE
Multiple export targets per profile

### DIFF
--- a/regolith/config.go
+++ b/regolith/config.go
@@ -1,6 +1,7 @@
 package regolith
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
@@ -35,6 +36,37 @@ type ExportTarget struct {
 	WorldPath string `json:"worldPath,omitempty"`
 	ReadOnly  bool   `json:"readOnly"`        // Whether the exported files should be read-only
 	Build     string `json:"build,omitempty"` // The type of Minecraft build for the 'develop'
+}
+
+// ExportTargets is the config representation of a profile's "export" value.
+// It accepts both the single-object form and the multi-target array
+// form. When marshaling, a single target is written as an object to keep newly
+// generated configs backward compatible with older Regolith versions.
+type ExportTargets []ExportTarget
+
+// IsZero lets json:",omitzero" omit an unset target list.
+func (et ExportTargets) IsZero() bool {
+	return len(et) == 0
+}
+
+func (et ExportTargets) MarshalJSON() ([]byte, error) {
+	if len(et) == 1 {
+		return json.Marshal(et[0])
+	}
+	return json.Marshal([]ExportTarget(et))
+}
+
+func (et *ExportTargets) UnmarshalJSON(data []byte) error {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	targets, err := ExportTargetsFromObject(raw)
+	if err != nil {
+		return err
+	}
+	*et = targets
+	return nil
 }
 
 // Packs is a part of "config.json" that points to the source behavior and
@@ -205,6 +237,42 @@ func RegolithProjectFromObject(
 		result.Profiles[profileName] = profileValue
 	}
 	return result, nil
+}
+
+// ExportTargetsFromObject parses the "export" value which can be either a
+// single object (backward compatible) or an array of objects.
+func ExportTargetsFromObject(exportValue any) (ExportTargets, error) {
+	switch v := exportValue.(type) {
+	case map[string]any:
+		et, err := ExportTargetFromObject(v)
+		if err != nil {
+			return nil, burrito.WrapErrorf(err, jsonPropertyParseError, "export")
+		}
+		return ExportTargets{et}, nil
+	case []any:
+		if len(v) == 0 {
+			return nil, burrito.WrappedErrorf(
+				"The \"export\" array must contain at least one entry")
+		}
+		targets := make(ExportTargets, 0, len(v))
+		for i, item := range v {
+			obj, ok := item.(map[string]any)
+			if !ok {
+				return nil, burrito.WrappedErrorf(
+					jsonPathTypeError, fmt.Sprintf("export->%d", i), "object")
+			}
+			et, err := ExportTargetFromObject(obj)
+			if err != nil {
+				return nil, burrito.WrapErrorf(
+					err, jsonPropertyParseError, fmt.Sprintf("export->%d", i))
+			}
+			targets = append(targets, et)
+		}
+		return targets, nil
+	default:
+		return nil, burrito.WrappedErrorf(
+			jsonPropertyTypeError, "export", "object or array")
+	}
 }
 
 // ExportTargetFromObject creates a "ExportTarget" object from

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -3,10 +3,12 @@ package regolith
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
+	"github.com/otiai10/copy"
 	"golang.org/x/mod/semver"
 )
 
@@ -224,67 +226,88 @@ func GetExportNames(exportTarget ExportTarget, ctx RunContext) (bpName string, r
 	return
 }
 
+type resolvedExportTarget struct {
+	target ExportTarget
+	bpPath string
+	rpPath string
+}
+
 // ExportProject copies files from the tmp paths (tmp/BP and tmp/RP) into
-// the project's export target. The paths are generated with GetExportPaths.
+// the project's export targets. The paths are generated with GetExportPaths.
 func ExportProject(ctx RunContext) error {
 	MeasureStart("Export - GetExportPaths")
 	profile, err := ctx.GetProfile()
 	if err != nil {
 		return burrito.WrapError(err, runContextGetProfileError)
 	}
-	if profile.ExportTarget.Target == "none" {
-		Logger.Debugf("Export target is set to \"none\". Skipping export.")
+	// Resolve all non-"none" targets before modifying any export path. This
+	// keeps failure atomic when a later target has an invalid path or unsafe
+	// existing files.
+	var activeTargets []resolvedExportTarget
+	for _, exportTarget := range profile.activeExportTargets() {
+		bpPath, rpPath, err := GetExportPaths(exportTarget, ctx)
+		if err != nil {
+			return burrito.WrapError(err, getExportPathsError)
+		}
+		activeTargets = append(activeTargets, resolvedExportTarget{
+			target: exportTarget,
+			bpPath: bpPath,
+			rpPath: rpPath,
+		})
+	}
+	if len(activeTargets) == 0 {
+		Logger.Debugf("All export targets are set to \"none\". Skipping export.")
 		return nil
 	}
-	// Get the necessary paths and variables
 	dotRegolithPath := ctx.DotRegolithPath
-	exportTarget := profile.ExportTarget
-	bpPath, rpPath, err := GetExportPaths(exportTarget, ctx)
-	if err != nil {
-		return burrito.WrapError(
-			err, getExportPathsError)
-	}
-	// Load edited files
-	MeasureStart("Export - CheckDeletionSafety")
+	useSymlink := IsExperimentEnabled(SymlinkExport) && len(activeTargets) == 1
 	editedFiles := LoadEditedFiles(dotRegolithPath)
-	err = editedFiles.CheckDeletionSafety(rpPath, bpPath)
-	if err != nil {
-		return burrito.WrapErrorf(
-			err,
-			checkDeletionSafetyError,
-			rpPath, bpPath)
-	}
-	// Export RP and BP if necessary
-	if IsExperimentEnabled(SymlinkExport) {
-		Logger.Debugf("SymlinkExport experiment is enabled. Skipping RP and BP export.")
-	} else {
-		err = exportProjectRpAndBp(profile, rpPath, bpPath, ctx)
+
+	for _, exportTarget := range activeTargets {
+		MeasureStart("Export - CheckDeletionSafety")
+		err = editedFiles.CheckDeletionSafety(exportTarget.rpPath, exportTarget.bpPath)
 		if err != nil {
-			return burrito.PassError(err)
+			return burrito.WrapErrorf(
+				err, checkDeletionSafetyError, exportTarget.rpPath, exportTarget.bpPath)
 		}
 	}
-	// Export data for exportData filters
-	MeasureStart("Export - ExportData")
-	err = exportProjectData(profile, ctx)
-	if err != nil {
-		return burrito.PassError(err)
+
+	for i, exportTarget := range activeTargets {
+		// Symlink export already placed files for the only active target.
+		if useSymlink && i == 0 {
+			Logger.Debugf("SymlinkExport experiment is enabled. Skipping RP and BP export.")
+		} else {
+			// Move is only safe when there is exactly one active target
+			// and symlink export is off, since tmp/ is the sole source and
+			// moving from a symlinked tmp would destroy the first target.
+			canMove := len(activeTargets) == 1 && !useSymlink
+			err = exportProjectRpAndBp(
+				exportTarget.target, exportTarget.rpPath, exportTarget.bpPath,
+				ctx, canMove)
+			if err != nil {
+				return burrito.PassError(err)
+			}
+		}
 	}
 	MeasureStart("Export - EditedFiles.UpdateFromPaths")
-	// Update or create edited_files.json
-	err = editedFiles.UpdateFromPaths(rpPath, bpPath)
-	if err != nil {
-		return burrito.WrapError(
-			err,
-			"Failed to create a list of files edited by this 'regolith run'")
+	for _, exportTarget := range activeTargets {
+		err = editedFiles.UpdateFromPaths(exportTarget.rpPath, exportTarget.bpPath)
+		if err != nil {
+			return burrito.WrapError(
+				err,
+				"Failed to create a list of files edited by this 'regolith run'")
+		}
 	}
 	err = editedFiles.Dump(dotRegolithPath)
 	if err != nil {
 		return burrito.WrapError(err, updatedFilesDumpError)
 	}
-	// Remove the exported pack paths if they're empty
-	if !IsExperimentEnabled(SymlinkExport) {
-		MeasureStart("Export - Remove Empty Export Paths")
-		for _, packPath := range []string{rpPath, bpPath} {
+	MeasureStart("Export - Remove Empty Export Paths")
+	for i, exportTarget := range activeTargets {
+		if useSymlink && i == 0 {
+			continue
+		}
+		for _, packPath := range []string{exportTarget.rpPath, exportTarget.bpPath} {
 			pathEmpty, _ := IsDirEmpty(packPath)
 			if pathEmpty {
 				if err := os.Remove(packPath); err != nil {
@@ -296,22 +319,25 @@ func ExportProject(ctx RunContext) error {
 			}
 		}
 	}
+	// Export data once (not per target)
+	MeasureStart("Export - ExportData")
+	err = exportProjectData(profile, ctx)
+	if err != nil {
+		return burrito.PassError(err)
+	}
 	MeasureEnd()
 	return nil
 }
 
-// exportProjectRpAndBp is a helper function for ExportProject. It exports the 'rp'
-// and 'bp' folders to the target location. This assumes that the symlinkExport
-// is disabled.
-func exportProjectRpAndBp(profile Profile, rpPath, bpPath string, ctx RunContext) error {
+// exportProjectRpAndBp is a helper function for ExportProject. It exports the
+// 'rp' and 'bp' folders to the target location. Moving is only safe for a
+// single active target without symlink export, since the tmp source must remain
+// intact for additional targets.
+func exportProjectRpAndBp(exportTarget ExportTarget, rpPath, bpPath string, ctx RunContext, allowMove bool) error {
 	dotRegolithPath := ctx.DotRegolithPath
-	exportTarget := profile.ExportTarget
 
 	var err error
-	// When comparing the size and modification time of the files, we need to
-	// keep the files in target paths.
 	if !IsExperimentEnabled(SizeTimeCheck) {
-		// Clearing output locations
 		MeasureStart("Export - Clean")
 		err = os.RemoveAll(bpPath)
 		if err != nil {
@@ -348,8 +374,10 @@ func exportProjectRpAndBp(profile Profile, rpPath, bpPath string, ctx RunContext
 			var e error
 			if IsExperimentEnabled(SizeTimeCheck) {
 				e = SyncDirectories(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly)
-			} else {
+			} else if allowMove {
 				e = MoveOrCopy(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly, true)
+			} else {
+				e = copyExportPath(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly)
 			}
 			if e != nil {
 				errChan <- burrito.WrapErrorf(e, "Failed to export %s pack.", packType)
@@ -365,6 +393,27 @@ func exportProjectRpAndBp(profile Profile, rpPath, bpPath string, ctx RunContext
 		if e != nil {
 			return e
 		}
+	}
+	return nil
+}
+
+func copyExportPath(source, destination string, makeReadOnly bool) error {
+	copySource := source
+	if resolvedSource, err := filepath.EvalSymlinks(source); err == nil {
+		copySource = resolvedSource
+	}
+	copyOptions := copy.Options{
+		PreserveTimes: false,
+		Sync:          false,
+	}
+	if runtime.GOOS == "windows" {
+		copyOptions.PermissionControl = copy.DoNothing
+	}
+	if err := copy.Copy(copySource, destination, copyOptions); err != nil {
+		return burrito.WrapErrorf(err, osCopyError, source, destination)
+	}
+	if makeReadOnly {
+		setPathReadOnly(destination)
 	}
 	return nil
 }
@@ -404,6 +453,9 @@ func exportProjectData(profile Profile, ctx RunContext) error {
 	}, true)
 	if err != nil {
 		return burrito.WrapError(err, "Failed to walk the list of the filters.")
+	}
+	if len(exportedFilterNames) == 0 {
+		return nil
 	}
 	// The root of the data path cannot be deleted because the
 	// "regolith watch" function would stop watching the file changes

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -1,6 +1,7 @@
 package regolith
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -232,6 +233,51 @@ type resolvedExportTarget struct {
 	rpPath string
 }
 
+func normalizeExportPathForCollision(path string) (string, error) {
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", burrito.WrapErrorf(err, filepathAbsError, path)
+	}
+	if resolvedPath, err := filepath.EvalSymlinks(absPath); err == nil {
+		absPath = resolvedPath
+	}
+	if runtime.GOOS == "windows" {
+		absPath = strings.ToLower(absPath)
+	}
+	return absPath, nil
+}
+
+func pathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator)) &&
+		!filepath.IsAbs(rel)
+}
+
+func checkExportPathCollision(seen map[string]string, path, label string) error {
+	normalizedPath, err := normalizeExportPathForCollision(path)
+	if err != nil {
+		return burrito.PassError(err)
+	}
+	for seenPath, seenLabel := range seen {
+		if normalizedPath == seenPath ||
+			pathContains(normalizedPath, seenPath) ||
+			pathContains(seenPath, normalizedPath) {
+			return burrito.WrappedErrorf(
+				"Export path collision detected.\n"+
+					"First path: %s\n"+
+					"Second path: %s\n"+
+					"Overlapping path: %s",
+				seenLabel, label, normalizedPath)
+		}
+	}
+	seen[normalizedPath] = label
+	return nil
+}
+
 // ExportProject copies files from the tmp paths (tmp/BP and tmp/RP) into
 // the project's export targets. The paths are generated with GetExportPaths.
 func ExportProject(ctx RunContext) error {
@@ -244,10 +290,18 @@ func ExportProject(ctx RunContext) error {
 	// keeps failure atomic when a later target has an invalid path or unsafe
 	// existing files.
 	var activeTargets []resolvedExportTarget
-	for _, exportTarget := range profile.activeExportTargets() {
+	seenExportPaths := make(map[string]string)
+	for i, exportTarget := range profile.activeExportTargets() {
 		bpPath, rpPath, err := GetExportPaths(exportTarget, ctx)
 		if err != nil {
 			return burrito.WrapError(err, getExportPathsError)
+		}
+		targetLabel := fmt.Sprintf("export target %d (%s)", i+1, exportTarget.Target)
+		if err := checkExportPathCollision(seenExportPaths, bpPath, targetLabel+" behavior pack: "+bpPath); err != nil {
+			return burrito.PassError(err)
+		}
+		if err := checkExportPathCollision(seenExportPaths, rpPath, targetLabel+" resource pack: "+rpPath); err != nil {
+			return burrito.PassError(err)
 		}
 		activeTargets = append(activeTargets, resolvedExportTarget{
 			target: exportTarget,

--- a/regolith/file_system.go
+++ b/regolith/file_system.go
@@ -821,31 +821,33 @@ func MoveOrCopy(
 			return err
 		}
 	}
-	// Make files read only if this option is selected
 	if makeReadOnly {
-		Logger.Infof("Changing the access for output path to "+
-			"read-only.\n\tPath: %s", destination)
-		err := filepath.WalkDir(destination,
-			func(s string, d fs.DirEntry, e error) error {
-
-				if e != nil {
-					// Error message isn't important as it's not passed further
-					// in the code
-					return e
-				}
-				if !d.IsDir() {
-					os.Chmod(s, 0444)
-				}
-				return nil
-			})
-		if err != nil {
-			Logger.Warnf(
-				"Failed to change access of the output path to read-only.\n"+
-					"\tPath: %s",
-				destination)
-		}
+		setPathReadOnly(destination)
 	}
 	return nil
+}
+
+func setPathReadOnly(path string) {
+	Logger.Infof("Changing the access for output path to "+
+		"read-only.\n\tPath: %s", path)
+	err := filepath.WalkDir(path,
+		func(s string, d fs.DirEntry, e error) error {
+			if e != nil {
+				// Error message isn't important as it's not passed further
+				// in the code.
+				return e
+			}
+			if !d.IsDir() {
+				os.Chmod(s, 0444)
+			}
+			return nil
+		})
+	if err != nil {
+		Logger.Warnf(
+			"Failed to change access of the output path to read-only.\n"+
+				"\tPath: %s",
+			path)
+	}
 }
 
 // SyncDirectories copies the source to destination while checking size and modification time.

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -487,10 +487,12 @@ func Init(debug, force bool, env string) error {
 					FilterCollection: FilterCollection{
 						Filters: []FilterRunner{},
 					},
-					ExportTarget: ExportTarget{
-						Target:   "development",
-						Build:    "standard",
-						ReadOnly: false,
+					ExportTargets: ExportTargets{
+						{
+							Target:   "development",
+							Build:    "standard",
+							ReadOnly: false,
+						},
 					},
 				},
 			},

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -488,7 +488,7 @@ func Init(debug, force bool, env string) error {
 					FilterCollection: FilterCollection{
 						Filters: []FilterRunner{},
 					},
-					ExportTargets: ExportTargets{
+					ExportTarget: ExportTargets{
 						{
 							Target:   "development",
 							Build:    "standard",

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -136,16 +136,20 @@ func SetupTmpFiles(context RunContext) error {
 		if err != nil {
 			return burrito.WrapErrorf(err, runContextGetProfileError)
 		}
-		bpExportPath, rpExportPath, err = GetExportPaths(profile.ExportTarget, context)
-		if err != nil {
-			return burrito.WrapError(err, getExportPathsError)
-		}
-		if profile.ExportTarget.Target == "none" {
+		activeTargets := profile.activeExportTargets()
+		if len(activeTargets) != 1 {
+			if len(activeTargets) > 1 {
+				Logger.Debugf("SymlinkExport experiment is enabled but the profile has multiple active export targets. Using regular export.")
+			}
 			useSymlinkExport = false
 		} else {
+			primaryTarget := activeTargets[0]
+			bpExportPath, rpExportPath, err = GetExportPaths(primaryTarget, context)
+			if err != nil {
+				return burrito.WrapError(err, getExportPathsError)
+			}
 			bpLink := isSymlinkTo(bpTmpPath, bpExportPath)
 			rpLink := isSymlinkTo(rpTmpPath, rpExportPath)
-			// If either symlink doesn't exist, create them
 			shouldCreateSymlinks = !bpLink || !rpLink
 		}
 	}
@@ -552,13 +556,53 @@ func (sc *ShellCommands) GetCommandsForCurrentOS() []string {
 	}
 }
 
-// Profile is a collection of filters and an export target
-// When editing, adjust ProfileFromObject function as well
+// Profile is a collection of filters and export targets.
+// When editing, adjust ProfileFromObject function as well.
 type Profile struct {
 	FilterCollection
-	ExportTarget ExportTarget  `json:"export,omitzero"`
+	ExportTargets ExportTargets `json:"export,omitzero"`
+	// Deprecated: use ExportTargets. This field is kept as a compatibility
+	// fallback for Go callers that still build Profile values with one export
+	// target.
+	ExportTarget ExportTarget  `json:"-"`
 	PreShell     ShellCommands `json:"preShell,omitzero"`
 	PostShell    ShellCommands `json:"postShell,omitzero"`
+}
+
+func (p Profile) exportTargets() ExportTargets {
+	if len(p.ExportTargets) > 0 {
+		return p.ExportTargets
+	}
+	if p.ExportTarget.Target != "" {
+		return ExportTargets{p.ExportTarget}
+	}
+	return nil
+}
+
+func (p Profile) activeExportTargets() ExportTargets {
+	targets := p.exportTargets()
+	activeTargets := make(ExportTargets, 0, len(targets))
+	for _, target := range targets {
+		if target.Target != "none" {
+			activeTargets = append(activeTargets, target)
+		}
+	}
+	return activeTargets
+}
+
+func (p Profile) MarshalJSON() ([]byte, error) {
+	type profileJSON struct {
+		Filters       []FilterRunner `json:"filters"`
+		ExportTargets ExportTargets  `json:"export,omitzero"`
+		PreShell      ShellCommands  `json:"preShell,omitzero"`
+		PostShell     ShellCommands  `json:"postShell,omitzero"`
+	}
+	return json.Marshal(profileJSON{
+		Filters:       p.Filters,
+		ExportTargets: p.exportTargets(),
+		PreShell:      p.PreShell,
+		PostShell:     p.PostShell,
+	})
 }
 
 func shellCommandsFromObject(obj map[string]any, key string) (ShellCommands, error) {
@@ -655,19 +699,19 @@ func ProfileFromObject(
 		}
 		result.Filters = append(result.Filters, filterRunner)
 	}
-	// ExportTarget
-	if _, ok := obj["export"]; !ok {
+	// ExportTargets
+	exportValue, ok := obj["export"]
+	if !ok {
 		return result, burrito.WrappedErrorf(jsonPathMissingError, "export")
 	}
-	export, ok := obj["export"].(map[string]any)
-	if !ok {
-		return result, burrito.WrappedErrorf(jsonPathTypeError, "export", "object")
-	}
-	exportTarget, err := ExportTargetFromObject(export)
+	exportTargets, err := ExportTargetsFromObject(exportValue)
 	if err != nil {
-		return result, burrito.WrapErrorf(err, jsonPathParseError, "export")
+		return result, burrito.PassError(err)
 	}
-	result.ExportTarget = exportTarget
+	result.ExportTargets = exportTargets
+	if len(exportTargets) > 0 {
+		result.ExportTarget = exportTargets[0]
+	}
 	// PreShell and PostShell
 	preShell, err := shellCommandsFromObject(obj, "preShell")
 	if err != nil {

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -562,23 +562,13 @@ func (sc *ShellCommands) GetCommandsForCurrentOS() []string {
 // When editing, adjust ProfileFromObject function as well.
 type Profile struct {
 	FilterCollection
-	ExportTargets ExportTargets `json:"export,omitzero"`
-	// Deprecated: use ExportTargets. This field is kept as a compatibility
-	// fallback for Go callers that still build Profile values with one export
-	// target.
-	ExportTarget ExportTarget  `json:"-"`
+	ExportTarget ExportTargets `json:"export,omitzero"`
 	PreShell     ShellCommands `json:"preShell,omitzero"`
 	PostShell    ShellCommands `json:"postShell,omitzero"`
 }
 
 func (p Profile) exportTargets() ExportTargets {
-	if len(p.ExportTargets) > 0 {
-		return p.ExportTargets
-	}
-	if p.ExportTarget.Target != "" {
-		return ExportTargets{p.ExportTarget}
-	}
-	return nil
+	return p.ExportTarget
 }
 
 func (p Profile) activeExportTargets() ExportTargets {
@@ -590,21 +580,6 @@ func (p Profile) activeExportTargets() ExportTargets {
 		}
 	}
 	return activeTargets
-}
-
-func (p Profile) MarshalJSON() ([]byte, error) {
-	type profileJSON struct {
-		Filters       []FilterRunner `json:"filters"`
-		ExportTargets ExportTargets  `json:"export,omitzero"`
-		PreShell      ShellCommands  `json:"preShell,omitzero"`
-		PostShell     ShellCommands  `json:"postShell,omitzero"`
-	}
-	return json.Marshal(profileJSON{
-		Filters:       p.Filters,
-		ExportTargets: p.exportTargets(),
-		PreShell:      p.PreShell,
-		PostShell:     p.PostShell,
-	})
 }
 
 func shellCommandsFromObject(obj map[string]any, key string) (ShellCommands, error) {
@@ -701,7 +676,7 @@ func ProfileFromObject(
 		}
 		result.Filters = append(result.Filters, filterRunner)
 	}
-	// ExportTargets
+	// ExportTarget
 	exportValue, ok := obj["export"]
 	if !ok {
 		return result, burrito.WrappedErrorf(jsonPathMissingError, "export")
@@ -710,10 +685,7 @@ func ProfileFromObject(
 	if err != nil {
 		return result, burrito.PassError(err)
 	}
-	result.ExportTargets = exportTargets
-	if len(exportTargets) > 0 {
-		result.ExportTarget = exportTargets[0]
-	}
+	result.ExportTarget = exportTargets
 	// PreShell and PostShell
 	preShell, err := shellCommandsFromObject(obj, "preShell")
 	if err != nil {

--- a/test/common.go
+++ b/test/common.go
@@ -249,6 +249,9 @@ func prepareTestDirectory(path string, t *testing.T) string {
 }
 
 func removeAllForTest(path string) error {
+	// Some tests export packs with readOnly enabled. On Windows, rerunning
+	// those tests can leave read-only files in test_results, so reset
+	// permissions before deleting the old test directory.
 	var err error
 	for range 3 {
 		_ = filepath.WalkDir(path, func(currPath string, entry fs.DirEntry, walkErr error) error {

--- a/test/common.go
+++ b/test/common.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/otiai10/copy"
 )
@@ -225,7 +226,7 @@ func prepareTestDirectory(path string, t *testing.T) string {
 	const testResultsDir = "test_results"
 	// Create the output directory
 	result := filepath.Join(testResultsDir, path)
-	if err := os.RemoveAll(result); err != nil {
+	if err := removeAllForTest(result); err != nil {
 		t.Fatalf(
 			"Failed to delete the files form the testing directory."+
 				"\nPath: %q\nError: %v",
@@ -247,6 +248,28 @@ func prepareTestDirectory(path string, t *testing.T) string {
 	return result
 }
 
+func removeAllForTest(path string) error {
+	var err error
+	for range 3 {
+		_ = filepath.WalkDir(path, func(currPath string, entry fs.DirEntry, walkErr error) error {
+			if walkErr == nil {
+				mode := os.FileMode(0666)
+				if entry.IsDir() {
+					mode = 0777
+				}
+				_ = os.Chmod(currPath, mode)
+			}
+			return nil
+		})
+		err = os.RemoveAll(path)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return err
+}
+
 // getWdOrFatal returns the current working directory or exits with t.Fatal in
 // case of error.
 func getWdOrFatal(t *testing.T) string {
@@ -262,7 +285,11 @@ func getWdOrFatal(t *testing.T) string {
 func copyFilesOrFatal(src, dest string, t *testing.T) {
 	os.MkdirAll(dest, 0755)
 	err := copy.Copy(
-		src, dest, copy.Options{PreserveTimes: false, Sync: false})
+		src, dest, copy.Options{
+			PreserveTimes:     false,
+			Sync:              false,
+			PermissionControl: copy.DoNothing,
+		})
 	if err != nil {
 		t.Fatalf(
 			"Failed to copy files.\nSource: %s\nDestination: %s\nError: %v",

--- a/test/export_targets_test.go
+++ b/test/export_targets_test.go
@@ -1,0 +1,444 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Bedrock-OSS/regolith/regolith"
+)
+
+func TestExportTargetsFromObject_SingleObject(t *testing.T) {
+	input := map[string]any{
+		"target":   "development",
+		"readOnly": false,
+	}
+	targets, err := regolith.ExportTargetsFromObject(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("Expected 1 target, got %d", len(targets))
+	}
+	if targets[0].Target != "development" {
+		t.Fatalf("Expected target \"development\", got %q", targets[0].Target)
+	}
+}
+
+func TestExportTargetsFromObject_Array(t *testing.T) {
+	input := []any{
+		map[string]any{"target": "development", "build": "standard"},
+		map[string]any{"target": "local"},
+	}
+	targets, err := regolith.ExportTargetsFromObject(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("Expected 2 targets, got %d", len(targets))
+	}
+	if targets[0].Target != "development" {
+		t.Fatalf("Expected first target \"development\", got %q", targets[0].Target)
+	}
+	if targets[0].Build != "standard" {
+		t.Fatalf("Expected first target build \"standard\", got %q", targets[0].Build)
+	}
+	if targets[1].Target != "local" {
+		t.Fatalf("Expected second target \"local\", got %q", targets[1].Target)
+	}
+}
+
+func TestExportTargetsFromObject_EmptyArray(t *testing.T) {
+	input := []any{}
+	_, err := regolith.ExportTargetsFromObject(input)
+	if err == nil {
+		t.Fatal("Expected error for empty array, got nil")
+	}
+}
+
+func TestExportTargetsFromObject_InvalidType(t *testing.T) {
+	_, err := regolith.ExportTargetsFromObject("invalid")
+	if err == nil {
+		t.Fatal("Expected error for invalid type, got nil")
+	}
+}
+
+func TestExportTargets_MarshalJSON_Single(t *testing.T) {
+	targets := regolith.ExportTargets{
+		{Target: "development", ReadOnly: false},
+	}
+	data, err := json.Marshal(targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Single target should marshal as an object, not an array
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("Single target should marshal as object, got: %s", string(data))
+	}
+	if obj["target"] != "development" {
+		t.Fatalf("Expected target \"development\", got %v", obj["target"])
+	}
+}
+
+func TestExportTargets_MarshalJSON_Multiple(t *testing.T) {
+	targets := regolith.ExportTargets{
+		{Target: "development"},
+		{Target: "local"},
+	}
+	data, err := json.Marshal(targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Multiple targets should marshal as an array
+	var arr []map[string]any
+	if err := json.Unmarshal(data, &arr); err != nil {
+		t.Fatalf("Multiple targets should marshal as array, got: %s", string(data))
+	}
+	if len(arr) != 2 {
+		t.Fatalf("Expected 2 elements, got %d", len(arr))
+	}
+}
+
+func TestExportTargets_UnmarshalJSON_Single(t *testing.T) {
+	data := []byte(`{"target": "development", "readOnly": true}`)
+	var targets regolith.ExportTargets
+	if err := json.Unmarshal(data, &targets); err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("Expected 1 target, got %d", len(targets))
+	}
+	if targets[0].Target != "development" {
+		t.Fatalf("Expected \"development\", got %q", targets[0].Target)
+	}
+	if !targets[0].ReadOnly {
+		t.Fatal("Expected ReadOnly to be true")
+	}
+}
+
+func TestExportTargets_UnmarshalJSON_Array(t *testing.T) {
+	data := []byte(`[{"target": "development"}, {"target": "exact", "bpPath": "./build/BP", "rpPath": "./build/RP"}]`)
+	var targets regolith.ExportTargets
+	if err := json.Unmarshal(data, &targets); err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("Expected 2 targets, got %d", len(targets))
+	}
+	if targets[1].BpPath != "./build/BP" {
+		t.Fatalf("Expected bpPath \"./build/BP\", got %q", targets[1].BpPath)
+	}
+}
+
+func TestExportTargets_UnmarshalJSON_InvalidObject(t *testing.T) {
+	data := []byte(`{"readOnly": true}`)
+	var targets regolith.ExportTargets
+	if err := json.Unmarshal(data, &targets); err == nil {
+		t.Fatal("Expected error for export target without target property")
+	}
+}
+
+func TestExportTargets_UnmarshalJSON_EmptyArray(t *testing.T) {
+	data := []byte(`[]`)
+	var targets regolith.ExportTargets
+	if err := json.Unmarshal(data, &targets); err == nil {
+		t.Fatal("Expected error for empty export target array")
+	}
+}
+
+func TestExportTargets_RoundTrip(t *testing.T) {
+	original := regolith.ExportTargets{
+		{Target: "development", Build: "standard", ReadOnly: true},
+		{Target: "exact", BpPath: "./bp", RpPath: "./rp"},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded regolith.ExportTargets
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != len(original) {
+		t.Fatalf("Expected %d targets, got %d", len(original), len(decoded))
+	}
+	for i := range original {
+		if decoded[i].Target != original[i].Target {
+			t.Fatalf("Target %d: expected %q, got %q", i, original[i].Target, decoded[i].Target)
+		}
+	}
+}
+
+func TestProfileFromObject_SingleExportSetsCompatibilityField(t *testing.T) {
+	profile, err := regolith.ProfileFromObject(
+		map[string]any{
+			"filters": []any{},
+			"export": map[string]any{
+				"target": "local",
+			},
+		},
+		map[string]regolith.FilterInstaller{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(profile.ExportTargets) != 1 {
+		t.Fatalf("Expected 1 target, got %d", len(profile.ExportTargets))
+	}
+	if profile.ExportTargets[0].Target != "local" {
+		t.Fatalf("Expected ExportTargets[0] to be local, got %q", profile.ExportTargets[0].Target)
+	}
+	if profile.ExportTarget.Target != "local" {
+		t.Fatalf("Expected deprecated ExportTarget fallback to be local, got %q", profile.ExportTarget.Target)
+	}
+}
+
+func TestProfileMarshalJSON_DeprecatedExportTargetFallback(t *testing.T) {
+	profile := regolith.Profile{
+		FilterCollection: regolith.FilterCollection{
+			Filters: []regolith.FilterRunner{},
+		},
+		ExportTarget: regolith.ExportTarget{
+			Target: "local",
+		},
+	}
+	data, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatal(err)
+	}
+	exportObj, ok := obj["export"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected export to marshal as an object, got: %s", data)
+	}
+	if exportObj["target"] != "local" {
+		t.Fatalf("Expected target local, got %v", exportObj["target"])
+	}
+}
+
+func TestRunWithMultipleExactExportTargets(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(minimalProjectPath, workingDir, t)
+
+	config := []byte(`{
+		"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.2.json",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPack": "./packs/BP",
+			"resourcePack": "./packs/RP"
+		},
+		"regolith": {
+			"profiles": {
+				"multi": {
+					"filters": [],
+					"export": [
+						{
+							"target": "exact",
+							"rpPath": "../target-a/RP",
+							"bpPath": "../target-a/BP"
+						},
+						{
+							"target": "exact",
+							"rpPath": "../target-b/RP",
+							"bpPath": "../target-b/BP"
+						}
+					]
+				}
+			},
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal("Unable to write multi-target config:", err)
+	}
+
+	os.Chdir(workingDir)
+	if err := regolith.Run("multi", []string{}, true, ""); err != nil {
+		t.Fatal("First multi-target run failed:", err)
+	}
+
+	for _, target := range []string{"target-a", "target-b"} {
+		comparePaths(
+			filepath.Join(workingDir, "packs", "BP"),
+			filepath.Join(tmpDir, target, "BP"),
+			t,
+		)
+		comparePaths(
+			filepath.Join(workingDir, "packs", "RP"),
+			filepath.Join(tmpDir, target, "RP"),
+			t,
+		)
+	}
+
+	if err := regolith.Run("multi", []string{}, true, ""); err != nil {
+		t.Fatal("Second multi-target run failed safety checks:", err)
+	}
+
+	unexpectedFile := filepath.Join(tmpDir, "target-a", "BP", "unexpected.txt")
+	if err := os.WriteFile(unexpectedFile, []byte("not created by regolith"), 0644); err != nil {
+		t.Fatal("Unable to create unexpected target file:", err)
+	}
+	if err := regolith.Run("multi", []string{}, true, ""); err == nil {
+		t.Fatal("Expected file protection to reject unexpected file in first target")
+	}
+}
+
+func TestRunWithMultipleTargetsIgnoresSymlinkExport(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	oldExperiments := regolith.EnabledExperiments
+	regolith.EnabledExperiments = []string{"symlink_export"}
+	t.Cleanup(func() {
+		regolith.EnabledExperiments = oldExperiments
+	})
+
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(minimalProjectPath, workingDir, t)
+
+	config := []byte(`{
+		"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.2.json",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPack": "./packs/BP",
+			"resourcePack": "./packs/RP"
+		},
+		"regolith": {
+			"profiles": {
+				"multi": {
+					"filters": [],
+					"export": [
+						{
+							"target": "exact",
+							"rpPath": "../target-a/RP",
+							"bpPath": "../target-a/BP"
+						},
+						{
+							"target": "exact",
+							"rpPath": "../target-b/RP",
+							"bpPath": "../target-b/BP"
+						}
+					]
+				}
+			},
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal("Unable to write multi-target config:", err)
+	}
+
+	os.Chdir(workingDir)
+	if err := regolith.Run("multi", []string{}, true, ""); err != nil {
+		t.Fatal("Multi-target run with symlink_export enabled failed:", err)
+	}
+
+	for _, tmpPack := range []string{"BP", "RP"} {
+		info, err := os.Lstat(filepath.Join(workingDir, ".regolith", "tmp", tmpPack))
+		if err != nil {
+			t.Fatalf("Unable to stat tmp %s path: %v", tmpPack, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("Expected tmp %s path to be a directory, got symlink", tmpPack)
+		}
+	}
+
+	for _, target := range []string{"target-a", "target-b"} {
+		comparePaths(
+			filepath.Join(workingDir, "packs", "BP"),
+			filepath.Join(tmpDir, target, "BP"),
+			t,
+		)
+		comparePaths(
+			filepath.Join(workingDir, "packs", "RP"),
+			filepath.Join(tmpDir, target, "RP"),
+			t,
+		)
+	}
+}
+
+func TestRunWithLocalAndDevelopmentExportTargets(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(minimalProjectPath, workingDir, t)
+
+	mojangDir := filepath.Join(tmpDir, "com.mojang")
+	if err := os.MkdirAll(mojangDir, 0755); err != nil {
+		t.Fatal("Unable to create fake com.mojang directory:", err)
+	}
+	t.Setenv("COM_MOJANG_PACKS", mojangDir)
+
+	config := []byte(`{
+		"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.4.json",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPack": "./packs/BP",
+			"resourcePack": "./packs/RP"
+		},
+		"regolith": {
+			"formatVersion": "1.4.0",
+			"profiles": {
+				"local_and_development": {
+					"filters": [],
+					"export": [
+						{
+							"target": "local"
+						},
+						{
+							"target": "development",
+							"build": "standard"
+						}
+					]
+				}
+			},
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal("Unable to write mixed-target config:", err)
+	}
+
+	os.Chdir(workingDir)
+	if err := regolith.Run("local_and_development", []string{}, false, ""); err != nil {
+		t.Fatal("First mixed-target run failed:", err)
+	}
+
+	expectedBp := filepath.Join(workingDir, "packs", "BP")
+	expectedRp := filepath.Join(workingDir, "packs", "RP")
+	bpName := "regolith_test_project_bp"
+	rpName := "regolith_test_project_rp"
+
+	comparePaths(expectedBp, filepath.Join(workingDir, "build", bpName), t)
+	comparePaths(expectedRp, filepath.Join(workingDir, "build", rpName), t)
+	comparePaths(
+		expectedBp,
+		filepath.Join(mojangDir, "development_behavior_packs", bpName),
+		t,
+	)
+	comparePaths(
+		expectedRp,
+		filepath.Join(mojangDir, "development_resource_packs", rpName),
+		t,
+	)
+
+	if err := regolith.Run("local_and_development", []string{}, false, ""); err != nil {
+		t.Fatal("Second mixed-target run failed safety checks:", err)
+	}
+}

--- a/test/export_targets_test.go
+++ b/test/export_targets_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -173,7 +174,7 @@ func TestExportTargets_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestProfileFromObject_SingleExportSetsCompatibilityField(t *testing.T) {
+func TestProfileFromObject_SingleExportSetsExportTarget(t *testing.T) {
 	profile, err := regolith.ProfileFromObject(
 		map[string]any{
 			"filters": []any{},
@@ -186,24 +187,21 @@ func TestProfileFromObject_SingleExportSetsCompatibilityField(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(profile.ExportTargets) != 1 {
-		t.Fatalf("Expected 1 target, got %d", len(profile.ExportTargets))
+	if len(profile.ExportTarget) != 1 {
+		t.Fatalf("Expected 1 target, got %d", len(profile.ExportTarget))
 	}
-	if profile.ExportTargets[0].Target != "local" {
-		t.Fatalf("Expected ExportTargets[0] to be local, got %q", profile.ExportTargets[0].Target)
-	}
-	if profile.ExportTarget.Target != "local" {
-		t.Fatalf("Expected deprecated ExportTarget fallback to be local, got %q", profile.ExportTarget.Target)
+	if profile.ExportTarget[0].Target != "local" {
+		t.Fatalf("Expected ExportTarget[0] to be local, got %q", profile.ExportTarget[0].Target)
 	}
 }
 
-func TestProfileMarshalJSON_DeprecatedExportTargetFallback(t *testing.T) {
+func TestProfileMarshalJSON_SingleExportTarget(t *testing.T) {
 	profile := regolith.Profile{
 		FilterCollection: regolith.FilterCollection{
 			Filters: []regolith.FilterRunner{},
 		},
-		ExportTarget: regolith.ExportTarget{
-			Target: "local",
+		ExportTarget: regolith.ExportTargets{
+			{Target: "local"},
 		},
 	}
 	data, err := json.Marshal(profile)
@@ -292,6 +290,64 @@ func TestRunWithMultipleExactExportTargets(t *testing.T) {
 	}
 	if err := regolith.Run("multi", []string{}, true, "", false); err == nil {
 		t.Fatal("Expected file protection to reject unexpected file in first target")
+	}
+}
+
+func TestRunWithOverlappingExportTargetsFails(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(minimalProjectPath, workingDir, t)
+
+	config := []byte(`{
+		"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.2.json",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPack": "./packs/BP",
+			"resourcePack": "./packs/RP"
+		},
+		"regolith": {
+			"profiles": {
+				"multi": {
+					"filters": [],
+					"export": [
+						{
+							"target": "exact",
+							"rpPath": "../target-a/RP",
+							"bpPath": "../target-a/BP"
+						},
+						{
+							"target": "exact",
+							"rpPath": "../target-b/RP",
+							"bpPath": "../target-a/BP/nested"
+						}
+					]
+				}
+			},
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal("Unable to write overlapping-target config:", err)
+	}
+
+	os.Chdir(workingDir)
+	err := regolith.Run("multi", []string{}, true, "", false)
+	if err == nil {
+		t.Fatal("Expected overlapping export paths to fail")
+	}
+	t.Logf("Got expected export path collision error:\n%v", err)
+	if !strings.Contains(err.Error(), "Export path collision detected") {
+		t.Fatalf("Expected export path collision error, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "target-a")); !os.IsNotExist(err) {
+		t.Fatal("Expected export to fail before creating target-a")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "target-b")); !os.IsNotExist(err) {
+		t.Fatal("Expected export to fail before creating target-b")
 	}
 }
 


### PR DESCRIPTION
- Backwards-compatible
- Symlinks not enabled for multi-export targets
- Empty arrays are rejected so `target: "none"` remains the explicit way to disable export.
- Tests included
