### PR TITLE
🤖 AI PR: Moving Features Out of Experiments

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
 	"github.com/stirante/go-simple-eval/eval"
@@ -290,6 +289,7 @@ func main() {
 	subcommands = append(subcommands, cmdInstallAll)
 
 	// regolith run
+	var symlinkExport, disableSizeTimeCheck bool
 	cmdRun := &cobra.Command{
 		Use:   "run [profile_name]",
 		Short: "Runs Regolith using specified profile",
@@ -302,12 +302,15 @@ func main() {
 				extraFilterArgs = args[1:]
 			}
 			env, _ := cmd.Flags().GetString("env")
-			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env)
+			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env, symlinkExport, disableSizeTimeCheck)
 		},
 	}
+	cmdRun.Flags().BoolVar(&symlinkExport, "symlink-export", false, "Creates links from the tmp directory to the export target so that files written to tmp are immediately reflected in the export location.")
+	cmdRun.Flags().BoolVar(&disableSizeTimeCheck, "disable-size-time-check", false, "Disables the size and modification time check optimization for file exporting.")
 	subcommands = append(subcommands, cmdRun)
 
 	// regolith watch
+	var watchSymlinkExport, watchDisableSizeTimeCheck bool
 	cmdWatch := &cobra.Command{
 		Use:   "watch [profile_name]",
 		Short: "Watches project files and automatically runs Regolith when they change",
@@ -320,9 +323,11 @@ func main() {
 				extraFilterArgs = args[1:]
 			}
 			env, _ := cmd.Flags().GetString("env")
-			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env)
+			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env, watchSymlinkExport, watchDisableSizeTimeCheck)
 		},
 	}
+	cmdWatch.Flags().BoolVar(&watchSymlinkExport, "symlink-export", false, "Creates links from the tmp directory to the export target so that files written to tmp are immediately reflected in the export location.")
+	cmdWatch.Flags().BoolVar(&watchDisableSizeTimeCheck, "disable-size-time-check", false, "Disables the size and modification time check optimization for file exporting.")
 	subcommands = append(subcommands, cmdWatch)
 
 	// regolith apply-filter
@@ -394,20 +399,10 @@ func main() {
 	}
 	subcommands = append(subcommands, cmdUpdateResolvers)
 
-	// Generate the description for the experiments
-	experimentDescs := make([]string, len(regolith.AvailableExperiments))
-	for i, experiment := range regolith.AvailableExperiments {
-		experimentDescs[i] = "- " + experiment.Name + " - " + strings.Trim(experiment.Description, "\n")
-	}
-
-	// add --debug, --timings and --experiment flag to every command
+	// add --debug and --timings flag to every command
 	for _, cmd := range subcommands {
 		cmd.Flags().BoolVarP(&burrito.PrintStackTrace, "debug", "", false, "Enables debugging")
 		cmd.Flags().BoolVarP(&regolith.EnableTimings, "timings", "", false, "Enables timing information")
-		cmd.Flags().StringSliceVar(
-			&regolith.EnabledExperiments, "experiments", nil,
-			"Enables experimental features. Currently supported experiments:\n"+
-				strings.Join(experimentDescs, "\n"))
 	}
 
 	// Build and run CLI

--- a/regolith/experiments.go
+++ b/regolith/experiments.go
@@ -5,35 +5,16 @@ import "slices"
 type Experiment int
 
 const (
-	// SizeTimeCheck is an experiment that checks the size and modification time when exporting
 	SizeTimeCheck Experiment = iota
-	// SymlinkExport links the temporary build directory with the export
-	// target using hard links when possible.
 	SymlinkExport
 )
-
-// The descriptions shouldn't be too wide, the text with their description is
-// indented a lot.
-const sizeTimeCheckDesc = `
-Activates optimization for file exporting by checking the size and
-modification time of files before exporting, and only exporting if
-the file has changed. This experiment applies to 'run' and 'watch'
-commands.
-`
-
-const symlinkExportDesc = `
-Creates links from the tmp directory to the export target so that files
-written to tmp are immediately reflected in the export location.`
 
 type ExperimentInfo struct {
 	Name        string
 	Description string
 }
 
-var AvailableExperiments = map[Experiment]ExperimentInfo{
-	SizeTimeCheck: {"size_time_check", sizeTimeCheckDesc},
-	SymlinkExport: {"symlink_export", symlinkExportDesc},
-}
+var AvailableExperiments = map[Experiment]ExperimentInfo{}
 
 var EnabledExperiments []string
 

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -255,8 +255,8 @@ func ExportProject(ctx RunContext) error {
 			rpPath, bpPath)
 	}
 	// Export RP and BP if necessary
-	if IsExperimentEnabled(SymlinkExport) {
-		Logger.Debugf("SymlinkExport experiment is enabled. Skipping RP and BP export.")
+	if ctx.SymlinkExportEnabled {
+		Logger.Debugf("Symlink export is enabled. Skipping RP and BP export.")
 	} else {
 		err = exportProjectRpAndBp(profile, rpPath, bpPath, ctx)
 		if err != nil {
@@ -282,7 +282,7 @@ func ExportProject(ctx RunContext) error {
 		return burrito.WrapError(err, updatedFilesDumpError)
 	}
 	// Remove the exported pack paths if they're empty
-	if !IsExperimentEnabled(SymlinkExport) {
+	if !ctx.SymlinkExportEnabled {
 		MeasureStart("Export - Remove Empty Export Paths")
 		for _, packPath := range []string{rpPath, bpPath} {
 			pathEmpty, _ := IsDirEmpty(packPath)
@@ -310,7 +310,7 @@ func exportProjectRpAndBp(profile Profile, rpPath, bpPath string, ctx RunContext
 	var err error
 	// When comparing the size and modification time of the files, we need to
 	// keep the files in target paths.
-	if !IsExperimentEnabled(SizeTimeCheck) {
+	if ctx.DisableSizeTimeCheck {
 		// Clearing output locations
 		MeasureStart("Export - Clean")
 		err = os.RemoveAll(bpPath)
@@ -342,7 +342,7 @@ func exportProjectRpAndBp(profile Profile, rpPath, bpPath string, ctx RunContext
 		wg.Go(func() {
 			Logger.Infof("Exporting %s pack to \"%s\".", packType, packPath)
 			var e error
-			if IsExperimentEnabled(SizeTimeCheck) {
+			if !ctx.DisableSizeTimeCheck {
 				e = SyncDirectories(filepath.Join(dotRegolithPath, tmpPath), packPath, exportTarget.ReadOnly)
 			} else {
 				e = MoveOrCopy(filepath.Join(dotRegolithPath, tmpPath), packPath, exportTarget.ReadOnly, true)

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -22,14 +22,16 @@ type Filter struct {
 }
 
 type RunContext struct {
-	Initial          bool
-	AbsoluteLocation string
-	Config           *Config
-	Profile          string
-	Parent           *RunContext
-	DotRegolithPath  string
-	Settings         map[string]any
-	ExtraArguments   []string
+	Initial               bool
+	AbsoluteLocation      string
+	Config                *Config
+	Profile               string
+	Parent                *RunContext
+	DotRegolithPath       string
+	Settings              map[string]any
+	ExtraArguments        []string
+	SymlinkExportEnabled  bool
+	DisableSizeTimeCheck bool
 
 	// interruption is a channel used to receive notifications about changes
 	// in the source files, in order to trigger a restart of the program in

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -217,7 +217,7 @@ func InstallAll(force, update, debug, refreshFilters bool, env string) error {
 
 // prepareRunContext prepares the context for the "regolith run" and
 // "regolith watch" commands.
-func prepareRunContext(profileName string, extraFilterArgs []string, debug bool, env string) (*RunContext, error) {
+func prepareRunContext(profileName string, extraFilterArgs []string, debug bool, env string, symlinkExport bool, disableSizeTimeCheck bool) (*RunContext, error) {
 	InitLogging(debug)
 	if err := loadEnvFileFromArg(env); err != nil {
 		return nil, burrito.WrapErrorf(err, loadEnvFileFromArgError, env)
@@ -256,22 +256,24 @@ func prepareRunContext(profileName string, extraFilterArgs []string, debug bool,
 	}
 	path, _ := filepath.Abs(".")
 	return &RunContext{
-		Initial:          true,
-		AbsoluteLocation: path,
-		Config:           config,
-		Parent:           nil,
-		Profile:          profileName,
-		DotRegolithPath:  dotRegolithPath,
-		Settings:         map[string]any{},
-		ExtraArguments:   extraFilterArgs,
+		Initial:               true,
+		AbsoluteLocation:      path,
+		Config:                config,
+		Parent:                nil,
+		Profile:               profileName,
+		DotRegolithPath:       dotRegolithPath,
+		Settings:              map[string]any{},
+		ExtraArguments:        extraFilterArgs,
+		SymlinkExportEnabled:  symlinkExport,
+		DisableSizeTimeCheck:  disableSizeTimeCheck,
 	}, nil
 }
 
 // Run handles the "regolith run" command. It runs selected profile and exports
 // created resource pack and behavior pack to the target destination.
-func Run(profileName string, extraFilterArgs []string, debug bool, env string) error {
+func Run(profileName string, extraFilterArgs []string, debug bool, env string, symlinkExport bool, disableSizeTimeCheck bool) error {
 	// Get the context
-	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env)
+	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env, symlinkExport, disableSizeTimeCheck)
 	defer ShutdownLogging()
 	if err != nil {
 		return burrito.PassError(err)
@@ -294,9 +296,9 @@ func Run(profileName string, extraFilterArgs []string, debug bool, env string) e
 // Watch handles the "regolith watch" command. It watches the project
 // directories, and it runs selected profile and exports created resource pack
 // and behavior pack to the target destination when the project changes.
-func Watch(profileName string, extraFilterArgs []string, debug bool, env string) error {
+func Watch(profileName string, extraFilterArgs []string, debug bool, env string, symlinkExport bool, disableSizeTimeCheck bool) error {
 	// Get the context
-	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env)
+	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env, symlinkExport, disableSizeTimeCheck)
 	defer ShutdownLogging()
 	if err != nil {
 		return burrito.PassError(err)

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -119,8 +119,8 @@ func SetupTmpFiles(context RunContext) error {
 	config := *context.Config
 	dotRegolithPath := context.DotRegolithPath
 	start := time.Now()
-	useSizeTimeCheck := IsExperimentEnabled(SizeTimeCheck)
-	useSymlinkExport := IsExperimentEnabled(SymlinkExport)
+	useSizeTimeCheck := !context.DisableSizeTimeCheck
+	useSymlinkExport := context.SymlinkExportEnabled
 	tmpPath := filepath.Join(dotRegolithPath, "tmp")
 	bpTmpPath := filepath.Join(tmpPath, "BP")
 	rpTmpPath := filepath.Join(tmpPath, "RP")
@@ -227,7 +227,7 @@ func SetupTmpFiles(context RunContext) error {
 					}
 				}
 			} else if stats.IsDir() {
-				if useSizeTimeCheck || useSymlinkExport {
+				if useSizeTimeCheck {
 					err = SyncDirectories(path, p, false)
 					if err != nil {
 						return burrito.WrapError(err, "Failed to export behavior pack.")

--- a/test/conditional_filters_test.go
+++ b/test/conditional_filters_test.go
@@ -29,7 +29,7 @@ func TestConditionalFilter(t *testing.T) {
 
 	// THE TEST
 	t.Log("Running Regolith with a conditional filter...")
-	if err := regolith.Run("default", []string{}, true, ""); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/custom_pack_name_test.go
+++ b/test/custom_pack_name_test.go
@@ -30,7 +30,7 @@ func TestCustomPackName(t *testing.T) {
 
 	// THE TEST
 	t.Log("Running Regolith with a conditional filter...")
-	if err := regolith.Run("default", []string{}, true, ""); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/development_export_windows_test.go
+++ b/test/development_export_windows_test.go
@@ -103,7 +103,7 @@ func _testCustomDevelopmentExportLocation(
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run(profileToRun, []string{}, true, "")
+	err = regolith.Run(profileToRun, []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/export_windows_test.go
+++ b/test/export_windows_test.go
@@ -88,7 +88,7 @@ func TestMoveFilesAcl(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("dev", true)
+	err = regolith.Run("dev", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/file_protection_test.go
+++ b/test/file_protection_test.go
@@ -34,18 +34,18 @@ func TestSwitchingExportTargets(t *testing.T) {
 	// Run Regolith with targets: A, B, A
 	t.Log("Testing the 'regolith run' with changing export targets...")
 	t.Log("Running Regolith with target A...")
-	err := regolith.Run("exact_export_A", []string{}, true, "")
+	err := regolith.Run("exact_export_A", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on first attempt to export to A:", err)
 	}
 	t.Log("Running Regolith with target B...")
-	err = regolith.Run("exact_export_B", []string{}, true, "")
+	err = regolith.Run("exact_export_B", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal("Unable RunProfile failed on attempt to export to B:", err)
 	}
 	t.Log("Running Regolith with target A (2nd time)...")
-	err = regolith.Run("exact_export_A", []string{}, true, "")
+	err = regolith.Run("exact_export_A", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on second attempt to export to A:", err)
@@ -78,7 +78,7 @@ func TestTriggerFileProtection(t *testing.T) {
 	// 1. Run Regolith (export to A)
 	t.Log("Testing the 'regolith run' with file protection...")
 	t.Log("Running Regolith...")
-	err := regolith.Run("exact_export_A", []string{}, true, "")
+	err := regolith.Run("exact_export_A", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on first attempt to export to A:", err)
@@ -94,7 +94,7 @@ func TestTriggerFileProtection(t *testing.T) {
 
 	// 3. Run Regolith (export to A), expect failure.
 	t.Log("Running Regolith (this should be stopped by file protection system)...")
-	err = regolith.Run("exact_export_A", []string{}, true, "")
+	err = regolith.Run("exact_export_A", []string{}, true, "", false, false)
 	if err == nil {
 		t.Fatal("Expected RunProfile to fail on second attempt to export to A")
 	}

--- a/test/filter_async_test.go
+++ b/test/filter_async_test.go
@@ -30,7 +30,7 @@ func TestAsyncFilter(t *testing.T) {
 	t.Log("Running Regolith with a conditional filter...")
 
 	start := time.Now()
-	if err := regolith.Run("default", []string{}, true, ""); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	duration := time.Since(start)

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -44,7 +44,7 @@ func TestRegolithRunMissingRp(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	// THE TEST
-	err := regolith.Run("dev", []string{}, true, "")
+	err := regolith.Run("dev", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}
@@ -71,7 +71,7 @@ func TestLocalRequirementsInstallAndRun(t *testing.T) {
 		t.Fatal("'regolith install-all' failed", err.Error())
 	}
 	t.Log("Testing the 'regolith run' command...")
-	if err := regolith.Run("dev", []string{}, true, ""); err != nil {
+	if err := regolith.Run("dev", []string{}, true, "", false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 }
@@ -95,7 +95,7 @@ func TestExeFilterRun(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	if err := regolith.Run("dev", []string{}, true, ""); err != nil {
+	if err := regolith.Run("dev", []string{}, true, "", false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	// TEST EVALUATION
@@ -125,7 +125,7 @@ func TestProfileFilterRun(t *testing.T) {
 	// THE TEST
 	// Invalid profile (shoud fail)
 	t.Log("Running invalid profile filter with circular dependencies (this should fail).")
-	err := regolith.Run("invalid_circular_profile_1", []string{}, true, "")
+	err := regolith.Run("invalid_circular_profile_1", []string{}, true, "", false, false)
 	if err == nil {
 		t.Fatal("'regolith run' didn't return an error after running" +
 			" a circular profile filter.")
@@ -134,7 +134,7 @@ func TestProfileFilterRun(t *testing.T) {
 	}
 	// Valid profile (should succeed)
 	t.Log("Running valid profile filter.")
-	err = regolith.Run("correct_nested_profile", []string{}, true, "")
+	err = regolith.Run("correct_nested_profile", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}

--- a/test/pre_post_shell_os_specific_test.go
+++ b/test/pre_post_shell_os_specific_test.go
@@ -27,7 +27,7 @@ func TestPrePostShellCommandsOSSpecific(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing OS-specific preShell and postShell commands...")
-	if err := regolith.Run("default", nil, true, ""); err != nil {
+	if err := regolith.Run("default", nil, true, "", false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/pre_post_shell_test.go
+++ b/test/pre_post_shell_test.go
@@ -27,7 +27,7 @@ func TestPrePostShellCommands(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command with preShell and postShell...")
-	if err := regolith.Run("default", nil, true, ""); err != nil {
+	if err := regolith.Run("default", nil, true, "", false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -38,7 +38,7 @@ func TestInstallAllAndRun(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("dev", []string{}, true, "")
+	err = regolith.Run("dev", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}
@@ -78,7 +78,7 @@ func TestDataModifyRemoteFilter(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("default", []string{}, true, "")
+	err = regolith.Run("default", []string{}, true, "", false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/size_time_check_optimization_method_test.go
+++ b/test/size_time_check_optimization_method_test.go
@@ -45,13 +45,10 @@ func TestSizeTimeCheckOptimizationCorectness(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	// THE TEST
-	// Enable the experiment
-	regolith.EnabledExperiments = append(regolith.EnabledExperiments, "size_time_check")
-
 	// Run the project
 	t.Log("Running Regolith...")
 
-	if err := regolith.Run("default", []string{}, true, ""); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	// TEST EVALUATION
@@ -83,9 +80,6 @@ func TestSizeTimeCheckOptimizationSpeed(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	// THE TEST
-	// Enable the experiment
-	regolith.EnabledExperiments = append(regolith.EnabledExperiments, "size_time_check")
-
 	// Run the project twice, the second run should be faster
 	runtimes := make([]time.Duration, 0)
 	for i := range 2 {
@@ -94,7 +88,7 @@ func TestSizeTimeCheckOptimizationSpeed(t *testing.T) {
 
 		// Start the timer
 		start := time.Now()
-		if err := regolith.Run("default", []string{}, true, ""); err != nil {
+		if err := regolith.Run("default", []string{}, true, "", false, false); err != nil {
 			t.Fatal("'regolith run' failed:", err.Error())
 		}
 		// Stop the timer


### PR DESCRIPTION
This PR was written completely by AI. At the moment of writing this comment, I have not reviewed any of it. It might be total garbage. Treat this as a PR from a complete stranger.



The AI's summary:
> - **`--experiments` flag removed**. Replaced with two dedicated CLI flags on `run` and `watch` commands:
>   - `--symlink-export` — enables symlink export (was `--experiments symlink_export`)
>   - `--disable-size-time-check` — disables size-time-check optimization (was opt-in via `--experiments size_time_check`, now **on by default**)
> - **Bug fix in `profile.go:230`**: `useSymlinkExport` no longer incorrectly triggers `SyncDirectories()`. The condition changed from `if useSizeTimeCheck || useSymlinkExport` to `if useSizeTimeCheck`.
> - **No more global variables** for these options. `SymlinkExportEnabled` and `DisableSizeTimeCheck` are now fields on `RunContext`, threaded through `prepareRunContext` → `Run`/`Watch`.
> - **`experiments.go`** infrastructure preserved with an empty `AvailableExperiments` map, ready for future experiments.
> - All test files updated to match the new `Run`/`Watch` signatures.