### PR TITLE
🤖 AI PR: Moving Features Out of Experiments

### DIFF
--- a/main.go
+++ b/main.go
@@ -227,6 +227,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&envFile, "env", "", "Path to a custom .env file to load")
 
 	var force bool
+	forceDesc := "Force the operation, overriding potential safeguards."
 	// regolith init
 	cmdInit := &cobra.Command{
 		Use:   "init",
@@ -238,10 +239,13 @@ func main() {
 		},
 	}
 	cmdInit.Flags().BoolVarP(
-		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
+		&force, "force", "f", false, forceDesc)
 	subcommands = append(subcommands, cmdInit)
 
 	profiles := []string{}
+	// Messages for common flags in 'regolith install' and 'regolith install-all'
+	forceFilterRefreshDesc := "Force filter cache refresh."
+
 	// regolith install
 	var update, resolverRefresh, filterRefresh bool
 	cmdInstall := &cobra.Command{
@@ -261,11 +265,11 @@ func main() {
 		},
 	}
 	cmdInstall.Flags().BoolVarP(
-		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
+		&force, "force", "f", false, forceDesc)
 	cmdInstall.Flags().BoolVar(
 		&resolverRefresh, "force-resolver-refresh", false, "Force resolvers refresh.")
 	cmdInstall.Flags().BoolVar(
-		&filterRefresh, "force-filter-refresh", false, "Force filter cache refresh.")
+		&filterRefresh, "force-filter-refresh", false, forceFilterRefreshDesc)
 	cmdInstall.Flags().BoolVarP(
 		&force, "update", "u", false, "An alias for --force flag. Use this flag to update filters.")
 	cmdInstall.Flags().StringSliceVarP(&profiles, "profile", "p", profiles, "Adds installed filters to the specified profiles. If no profile is provided, the filter will be added to the default profile.")
@@ -283,12 +287,17 @@ func main() {
 		},
 	}
 	cmdInstallAll.Flags().BoolVarP(
-		&force, "force", "f", false, "Force the operation, overriding potential safeguards.")
+		&force, "force", "f", false, forceDesc)
 	cmdInstallAll.Flags().BoolVarP(
 		&update, "update", "u", false, "Updates the remote filters to the latest stable version available.")
 	cmdInstallAll.Flags().BoolVar(
-		&filterRefresh, "force-filter-refresh", false, "Force filter cache refresh.")
+		&filterRefresh, "force-filter-refresh", false, forceFilterRefreshDesc)
 	subcommands = append(subcommands, cmdInstallAll)
+
+	// Messages for common flags in 'regolith run' and 'regolith watch'
+	unsafeDesc := "Disables file protection safety checks for faster exports."
+	symlinkExportDesc := "Creates links from the tmp directory to the export target so that files written to tmp are immediately reflected in the export location."
+	disableSizeTimeCheckDesc := "Disables the size and modification time check optimization for file exporting."
 
 	// regolith run
 	var symlinkExport, disableSizeTimeCheck bool
@@ -310,9 +319,9 @@ func main() {
 			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env, unsafe, symlink, disableStc)
 		},
 	}
-	cmdRun.Flags().Bool("unsafe", false, "Disables file protection safety checks for faster exports")
-	cmdRun.Flags().BoolVar(&symlinkExport, "symlink-export", false, "Creates links from the tmp directory to the export target so that files written to tmp are immediately reflected in the export location.")
-	cmdRun.Flags().BoolVar(&disableSizeTimeCheck, "disable-size-time-check", false, "Disables the size and modification time check optimization for file exporting.")
+	cmdRun.Flags().Bool("unsafe", false, unsafeDesc)
+	cmdRun.Flags().BoolVar(&symlinkExport, "symlink-export", false, symlinkExportDesc)
+	cmdRun.Flags().BoolVar(&disableSizeTimeCheck, "disable-size-time-check", false, disableSizeTimeCheckDesc)
 	subcommands = append(subcommands, cmdRun)
 
 	// regolith watch
@@ -334,9 +343,9 @@ func main() {
 			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env, unsafe, symlink, disableStc)
 		},
 	}
-	cmdWatch.Flags().Bool("unsafe", false, "Disables file protection safety checks for faster exports")
-	cmdWatch.Flags().BoolVar(&symlinkExport, "symlink-export", false, "Creates links from the tmp directory to the export target so that files written to tmp are immediately reflected in the export location.")
-	cmdWatch.Flags().BoolVar(&disableSizeTimeCheck, "disable-size-time-check", false, "Disables the size and modification time check optimization for file exporting.")
+	cmdWatch.Flags().Bool("unsafe", false, unsafeDesc)
+	cmdWatch.Flags().BoolVar(&symlinkExport, "symlink-export", false, symlinkExportDesc)
+	cmdWatch.Flags().BoolVar(&disableSizeTimeCheck, "disable-size-time-check", false, disableSizeTimeCheckDesc)
 	subcommands = append(subcommands, cmdWatch)
 
 	// regolith apply-filter

--- a/main.go
+++ b/main.go
@@ -417,9 +417,20 @@ func main() {
 	}
 	subcommands = append(subcommands, cmdUpdateResolvers)
 
+	// // Generate the description for the experiments
+	// experimentDescs := make([]string, len(regolith.AvailableExperiments))
+	// for i, experiment := range regolith.AvailableExperiments {
+	// 	experimentDescs[i] = "- " + experiment.Name + " - " + strings.Trim(experiment.Description, "\n")
+	// }
+
+	// add --debug, --timings and --experiment flag to every command
 	for _, cmd := range subcommands {
 		cmd.Flags().BoolVarP(&burrito.PrintStackTrace, "debug", "", false, "Enables debugging")
 		cmd.Flags().BoolVarP(&regolith.EnableTimings, "timings", "", false, "Enables timing information")
+		// cmd.Flags().StringSliceVar(
+		// 	&regolith.EnabledExperiments, "experiments", nil,
+		// 	"Enables experimental features. Currently supported experiments:\n"+
+		// 		strings.Join(experimentDescs, "\n"))
 	}
 
 	// Build and run CLI

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
 	"github.com/stirante/go-simple-eval/eval"
@@ -292,6 +291,7 @@ func main() {
 	subcommands = append(subcommands, cmdInstallAll)
 
 	// regolith run
+	var symlinkExport, disableSizeTimeCheck bool
 	cmdRun := &cobra.Command{
 		Use:   "run [profile_name]",
 		Short: "Runs Regolith using specified profile",
@@ -305,10 +305,14 @@ func main() {
 			}
 			env, _ := cmd.Flags().GetString("env")
 			unsafe, _ := cmd.Flags().GetBool("unsafe")
-			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env, unsafe)
+			symlink, _ := cmd.Flags().GetBool("symlink-export")
+			disableStc, _ := cmd.Flags().GetBool("disable-size-time-check")
+			err = regolith.Run(profile, extraFilterArgs, burrito.PrintStackTrace, env, unsafe, symlink, disableStc)
 		},
 	}
 	cmdRun.Flags().Bool("unsafe", false, "Disables file protection safety checks for faster exports")
+	cmdRun.Flags().BoolVar(&symlinkExport, "symlink-export", false, "Creates links from the tmp directory to the export target so that files written to tmp are immediately reflected in the export location.")
+	cmdRun.Flags().BoolVar(&disableSizeTimeCheck, "disable-size-time-check", false, "Disables the size and modification time check optimization for file exporting.")
 	subcommands = append(subcommands, cmdRun)
 
 	// regolith watch
@@ -325,10 +329,14 @@ func main() {
 			}
 			env, _ := cmd.Flags().GetString("env")
 			unsafe, _ := cmd.Flags().GetBool("unsafe")
-			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env, unsafe)
+			symlink, _ := cmd.Flags().GetBool("symlink-export")
+			disableStc, _ := cmd.Flags().GetBool("disable-size-time-check")
+			err = regolith.Watch(profile, extraFilterArgs, burrito.PrintStackTrace, env, unsafe, symlink, disableStc)
 		},
 	}
 	cmdWatch.Flags().Bool("unsafe", false, "Disables file protection safety checks for faster exports")
+	cmdWatch.Flags().BoolVar(&symlinkExport, "symlink-export", false, "Creates links from the tmp directory to the export target so that files written to tmp are immediately reflected in the export location.")
+	cmdWatch.Flags().BoolVar(&disableSizeTimeCheck, "disable-size-time-check", false, "Disables the size and modification time check optimization for file exporting.")
 	subcommands = append(subcommands, cmdWatch)
 
 	// regolith apply-filter
@@ -400,20 +408,9 @@ func main() {
 	}
 	subcommands = append(subcommands, cmdUpdateResolvers)
 
-	// Generate the description for the experiments
-	experimentDescs := make([]string, len(regolith.AvailableExperiments))
-	for i, experiment := range regolith.AvailableExperiments {
-		experimentDescs[i] = "- " + experiment.Name + " - " + strings.Trim(experiment.Description, "\n")
-	}
-
-	// add --debug, --timings and --experiment flag to every command
 	for _, cmd := range subcommands {
 		cmd.Flags().BoolVarP(&burrito.PrintStackTrace, "debug", "", false, "Enables debugging")
 		cmd.Flags().BoolVarP(&regolith.EnableTimings, "timings", "", false, "Enables timing information")
-		cmd.Flags().StringSliceVar(
-			&regolith.EnabledExperiments, "experiments", nil,
-			"Enables experimental features. Currently supported experiments:\n"+
-				strings.Join(experimentDescs, "\n"))
 	}
 
 	// Build and run CLI

--- a/regolith/experiments.go
+++ b/regolith/experiments.go
@@ -4,36 +4,12 @@ import "slices"
 
 type Experiment int
 
-const (
-	// SizeTimeCheck is an experiment that checks the size and modification time when exporting
-	SizeTimeCheck Experiment = iota
-	// SymlinkExport links the temporary build directory with the export
-	// target using hard links when possible.
-	SymlinkExport
-)
-
-// The descriptions shouldn't be too wide, the text with their description is
-// indented a lot.
-const sizeTimeCheckDesc = `
-Activates optimization for file exporting by checking the size and
-modification time of files before exporting, and only exporting if
-the file has changed. This experiment applies to 'run' and 'watch'
-commands.
-`
-
-const symlinkExportDesc = `
-Creates links from the tmp directory to the export target so that files
-written to tmp are immediately reflected in the export location.`
-
 type ExperimentInfo struct {
 	Name        string
 	Description string
 }
 
-var AvailableExperiments = map[Experiment]ExperimentInfo{
-	SizeTimeCheck: {"size_time_check", sizeTimeCheckDesc},
-	SymlinkExport: {"symlink_export", symlinkExportDesc},
-}
+var AvailableExperiments = map[Experiment]ExperimentInfo{}
 
 var EnabledExperiments []string
 

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -314,7 +314,7 @@ func ExportProject(ctx RunContext) error {
 		return nil
 	}
 	dotRegolithPath := ctx.DotRegolithPath
-	useSymlink := IsExperimentEnabled(SymlinkExport) && len(activeTargets) == 1
+	useSymlink := ctx.SymlinkExport && len(activeTargets) == 1
 	editedFiles := LoadEditedFiles(dotRegolithPath)
 	if !useSymlink && !ctx.UnsafeMode {
 		MeasureStart("Export - CheckDeletionSafety")
@@ -330,7 +330,7 @@ func ExportProject(ctx RunContext) error {
 	for i, exportTarget := range activeTargets {
 		// Symlink export already placed files for the only active target.
 		if useSymlink && i == 0 {
-			Logger.Debugf("SymlinkExport experiment is enabled. Skipping RP and BP export.")
+			Logger.Debugf("Symlink export is enabled. Skipping RP and BP export.")
 		} else {
 			// Move is only safe when there is exactly one active target
 			// and symlink export is off, since tmp/ is the sole source and
@@ -392,7 +392,7 @@ func exportProjectRpAndBp(exportTarget ExportTarget, rpPath, bpPath string, ctx 
 	dotRegolithPath := ctx.DotRegolithPath
 
 	var err error
-	if !IsExperimentEnabled(SizeTimeCheck) {
+	if ctx.DisableSizeTimeCheck {
 		MeasureStart("Export - Clean")
 		if err := removeJunctionSafe(bpPath); err != nil {
 			return burrito.WrapErrorf(
@@ -425,7 +425,7 @@ func exportProjectRpAndBp(exportTarget ExportTarget, rpPath, bpPath string, ctx 
 		wg.Go(func() {
 			Logger.Infof("Exporting %s pack to \"%s\".", packType, packPath)
 			var e error
-			if IsExperimentEnabled(SizeTimeCheck) {
+			if !ctx.DisableSizeTimeCheck {
 				e = SyncDirectories(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly)
 			} else if allowMove {
 				e = MoveOrCopy(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly, true)

--- a/regolith/filter.go
+++ b/regolith/filter.go
@@ -22,15 +22,17 @@ type Filter struct {
 }
 
 type RunContext struct {
-	Initial          bool
-	AbsoluteLocation string
-	Config           *Config
-	Profile          string
-	Parent           *RunContext
-	DotRegolithPath  string
-	Settings         map[string]any
-	ExtraArguments   []string
-	UnsafeMode       bool
+	Initial              bool
+	AbsoluteLocation     string
+	Config               *Config
+	Profile              string
+	Parent               *RunContext
+	DotRegolithPath      string
+	Settings             map[string]any
+	ExtraArguments       []string
+	UnsafeMode           bool
+	SymlinkExport        bool
+	DisableSizeTimeCheck bool
 
 	// interruption is a channel used to receive notifications about changes
 	// in the source files, in order to trigger a restart of the program in

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -217,7 +217,7 @@ func InstallAll(force, update, debug, refreshFilters bool, env string) error {
 
 // prepareRunContext prepares the context for the "regolith run" and
 // "regolith watch" commands.
-func prepareRunContext(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool) (*RunContext, error) {
+func prepareRunContext(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool, symlinkExport bool, disableSizeTimeCheck bool) (*RunContext, error) {
 	InitLogging(debug)
 	if err := loadEnvFileFromArg(env); err != nil {
 		return nil, burrito.WrapErrorf(err, loadEnvFileFromArgError, env)
@@ -256,23 +256,25 @@ func prepareRunContext(profileName string, extraFilterArgs []string, debug bool,
 	}
 	path, _ := filepath.Abs(".")
 	return &RunContext{
-		Initial:          true,
-		AbsoluteLocation: path,
-		Config:           config,
-		Parent:           nil,
-		Profile:          profileName,
-		DotRegolithPath:  dotRegolithPath,
-		Settings:         map[string]any{},
-		ExtraArguments:   extraFilterArgs,
-		UnsafeMode:       unsafeMode,
+		Initial:              true,
+		AbsoluteLocation:     path,
+		Config:               config,
+		Parent:               nil,
+		Profile:              profileName,
+		DotRegolithPath:      dotRegolithPath,
+		Settings:             map[string]any{},
+		ExtraArguments:       extraFilterArgs,
+		UnsafeMode:           unsafeMode,
+		SymlinkExport:        symlinkExport,
+		DisableSizeTimeCheck: disableSizeTimeCheck,
 	}, nil
 }
 
 // Run handles the "regolith run" command. It runs selected profile and exports
 // created resource pack and behavior pack to the target destination.
-func Run(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool) error {
+func Run(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool, symlinkExport bool, disableSizeTimeCheck bool) error {
 	// Get the context
-	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env, unsafeMode)
+	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env, unsafeMode, symlinkExport, disableSizeTimeCheck)
 	defer ShutdownLogging()
 	if err != nil {
 		return burrito.PassError(err)
@@ -295,9 +297,9 @@ func Run(profileName string, extraFilterArgs []string, debug bool, env string, u
 // Watch handles the "regolith watch" command. It watches the project
 // directories, and it runs selected profile and exports created resource pack
 // and behavior pack to the target destination when the project changes.
-func Watch(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool) error {
+func Watch(profileName string, extraFilterArgs []string, debug bool, env string, unsafeMode bool, symlinkExport bool, disableSizeTimeCheck bool) error {
 	// Get the context
-	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env, unsafeMode)
+	context, err := prepareRunContext(profileName, extraFilterArgs, debug, env, unsafeMode, symlinkExport, disableSizeTimeCheck)
 	defer ShutdownLogging()
 	if err != nil {
 		return burrito.PassError(err)

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -119,8 +119,8 @@ func SetupTmpFiles(context RunContext) error {
 	config := *context.Config
 	dotRegolithPath := context.DotRegolithPath
 	start := time.Now()
-	useSizeTimeCheck := IsExperimentEnabled(SizeTimeCheck)
-	useSymlinkExport := IsExperimentEnabled(SymlinkExport)
+	useSizeTimeCheck := !context.DisableSizeTimeCheck
+	useSymlinkExport := context.SymlinkExport
 	absTmpPath, err := GetAbsoluteWorkingDirectory(dotRegolithPath)
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
@@ -139,7 +139,7 @@ func SetupTmpFiles(context RunContext) error {
 		activeTargets := profile.activeExportTargets()
 		if len(activeTargets) != 1 {
 			if len(activeTargets) > 1 {
-				Logger.Debugf("SymlinkExport experiment is enabled but the profile has multiple active export targets. Using regular export.")
+				Logger.Debugf("Symlink export is enabled but the profile has multiple active export targets. Using regular export.")
 			}
 			useSymlinkExport = false
 		} else {
@@ -238,10 +238,18 @@ func SetupTmpFiles(context RunContext) error {
 					}
 				}
 			} else if stats.IsDir() {
-				if useSizeTimeCheck || useSymlinkExport {
+				if useSizeTimeCheck {
 					err = SyncDirectories(path, p, false)
 					if err != nil {
 						return burrito.WrapError(err, "Failed to export behavior pack.")
+					}
+				} else if useSymlinkExport {
+					err = copy.Copy(
+						path,
+						p,
+						copy.Options{PreserveTimes: false, Sync: true})
+					if err != nil {
+						return burrito.WrapErrorf(err, osCopyError, path, p)
 					}
 				} else {
 					err = copy.Copy(

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -243,14 +243,6 @@ func SetupTmpFiles(context RunContext) error {
 					if err != nil {
 						return burrito.WrapError(err, "Failed to export behavior pack.")
 					}
-				} else if useSymlinkExport {
-					err = copy.Copy(
-						path,
-						p,
-						copy.Options{PreserveTimes: false, Sync: true})
-					if err != nil {
-						return burrito.WrapErrorf(err, osCopyError, path, p)
-					}
 				} else {
 					err = copy.Copy(
 						path,

--- a/test/conditional_filters_test.go
+++ b/test/conditional_filters_test.go
@@ -29,7 +29,7 @@ func TestConditionalFilter(t *testing.T) {
 
 	// THE TEST
 	t.Log("Running Regolith with a conditional filter...")
-	if err := regolith.Run("default", []string{}, true, "", false); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false, false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/custom_pack_name_test.go
+++ b/test/custom_pack_name_test.go
@@ -30,7 +30,7 @@ func TestCustomPackName(t *testing.T) {
 
 	// THE TEST
 	t.Log("Running Regolith with a conditional filter...")
-	if err := regolith.Run("default", []string{}, true, "", false); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false, false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/development_export_windows_test.go
+++ b/test/development_export_windows_test.go
@@ -103,7 +103,7 @@ func _testCustomDevelopmentExportLocation(
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run(profileToRun, []string{}, true, "", false)
+	err = regolith.Run(profileToRun, []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/export_targets_test.go
+++ b/test/export_targets_test.go
@@ -263,7 +263,7 @@ func TestRunWithMultipleExactExportTargets(t *testing.T) {
 	}
 
 	os.Chdir(workingDir)
-	if err := regolith.Run("multi", []string{}, true, "", false); err != nil {
+	if err := regolith.Run("multi", []string{}, true, "", false, false, false); err != nil {
 		t.Fatal("First multi-target run failed:", err)
 	}
 
@@ -280,7 +280,7 @@ func TestRunWithMultipleExactExportTargets(t *testing.T) {
 		)
 	}
 
-	if err := regolith.Run("multi", []string{}, true, "", false); err != nil {
+	if err := regolith.Run("multi", []string{}, true, "", false, false, false); err != nil {
 		t.Fatal("Second multi-target run failed safety checks:", err)
 	}
 
@@ -288,7 +288,7 @@ func TestRunWithMultipleExactExportTargets(t *testing.T) {
 	if err := os.WriteFile(unexpectedFile, []byte("not created by regolith"), 0644); err != nil {
 		t.Fatal("Unable to create unexpected target file:", err)
 	}
-	if err := regolith.Run("multi", []string{}, true, "", false); err == nil {
+	if err := regolith.Run("multi", []string{}, true, "", false, false, false); err == nil {
 		t.Fatal("Expected file protection to reject unexpected file in first target")
 	}
 }
@@ -335,7 +335,7 @@ func TestRunWithOverlappingExportTargetsFails(t *testing.T) {
 	}
 
 	os.Chdir(workingDir)
-	err := regolith.Run("multi", []string{}, true, "", false)
+	err := regolith.Run("multi", []string{}, true, "", false, false, false)
 	if err == nil {
 		t.Fatal("Expected overlapping export paths to fail")
 	}
@@ -353,11 +353,6 @@ func TestRunWithOverlappingExportTargetsFails(t *testing.T) {
 
 func TestRunWithMultipleTargetsIgnoresSymlinkExport(t *testing.T) {
 	defer os.Chdir(getWdOrFatal(t))
-	oldExperiments := regolith.EnabledExperiments
-	regolith.EnabledExperiments = []string{"symlink_export"}
-	t.Cleanup(func() {
-		regolith.EnabledExperiments = oldExperiments
-	})
 
 	tmpDir := prepareTestDirectory(
 		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
@@ -398,8 +393,8 @@ func TestRunWithMultipleTargetsIgnoresSymlinkExport(t *testing.T) {
 	}
 
 	os.Chdir(workingDir)
-	if err := regolith.Run("multi", []string{}, true, "", false); err != nil {
-		t.Fatal("Multi-target run with symlink_export enabled failed:", err)
+	if err := regolith.Run("multi", []string{}, true, "", false, true, false); err != nil {
+		t.Fatal("Multi-target run with --symlink-export enabled failed:", err)
 	}
 
 	for _, tmpPack := range []string{"BP", "RP"} {
@@ -472,7 +467,7 @@ func TestRunWithLocalAndDevelopmentExportTargets(t *testing.T) {
 	}
 
 	os.Chdir(workingDir)
-	if err := regolith.Run("local_and_development", []string{}, false, "", false); err != nil {
+	if err := regolith.Run("local_and_development", []string{}, false, "", false, false, false); err != nil {
 		t.Fatal("First mixed-target run failed:", err)
 	}
 
@@ -494,7 +489,7 @@ func TestRunWithLocalAndDevelopmentExportTargets(t *testing.T) {
 		t,
 	)
 
-	if err := regolith.Run("local_and_development", []string{}, false, "", false); err != nil {
+	if err := regolith.Run("local_and_development", []string{}, false, "", false, false, false); err != nil {
 		t.Fatal("Second mixed-target run failed safety checks:", err)
 	}
 }

--- a/test/file_protection_test.go
+++ b/test/file_protection_test.go
@@ -34,18 +34,18 @@ func TestSwitchingExportTargets(t *testing.T) {
 	// Run Regolith with targets: A, B, A
 	t.Log("Testing the 'regolith run' with changing export targets...")
 	t.Log("Running Regolith with target A...")
-	err := regolith.Run("exact_export_A", []string{}, true, "", false)
+	err := regolith.Run("exact_export_A", []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on first attempt to export to A:", err)
 	}
 	t.Log("Running Regolith with target B...")
-	err = regolith.Run("exact_export_B", []string{}, true, "", false)
+	err = regolith.Run("exact_export_B", []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal("Unable RunProfile failed on attempt to export to B:", err)
 	}
 	t.Log("Running Regolith with target A (2nd time)...")
-	err = regolith.Run("exact_export_A", []string{}, true, "", false)
+	err = regolith.Run("exact_export_A", []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on second attempt to export to A:", err)
@@ -78,7 +78,7 @@ func TestTriggerFileProtection(t *testing.T) {
 	// 1. Run Regolith (export to A)
 	t.Log("Testing the 'regolith run' with file protection...")
 	t.Log("Running Regolith...")
-	err := regolith.Run("exact_export_A", []string{}, true, "", false)
+	err := regolith.Run("exact_export_A", []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal(
 			"Unable RunProfile failed on first attempt to export to A:", err)
@@ -94,7 +94,7 @@ func TestTriggerFileProtection(t *testing.T) {
 
 	// 3. Run Regolith (export to A), expect failure.
 	t.Log("Running Regolith (this should be stopped by file protection system)...")
-	err = regolith.Run("exact_export_A", []string{}, true, "", false)
+	err = regolith.Run("exact_export_A", []string{}, true, "", false, false, false)
 	if err == nil {
 		t.Fatal("Expected RunProfile to fail on second attempt to export to A")
 	}

--- a/test/filter_async_test.go
+++ b/test/filter_async_test.go
@@ -30,7 +30,7 @@ func TestAsyncFilter(t *testing.T) {
 	t.Log("Running Regolith with a conditional filter...")
 
 	start := time.Now()
-	if err := regolith.Run("default", []string{}, true, "", false); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false, false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	duration := time.Since(start)

--- a/test/local_filters_test.go
+++ b/test/local_filters_test.go
@@ -44,7 +44,7 @@ func TestRegolithRunMissingRp(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	// THE TEST
-	err := regolith.Run("dev", []string{}, true, "", false)
+	err := regolith.Run("dev", []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}
@@ -71,7 +71,7 @@ func TestLocalRequirementsInstallAndRun(t *testing.T) {
 		t.Fatal("'regolith install-all' failed", err.Error())
 	}
 	t.Log("Testing the 'regolith run' command...")
-	if err := regolith.Run("dev", []string{}, true, "", false); err != nil {
+	if err := regolith.Run("dev", []string{}, true, "", false, false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 }
@@ -95,7 +95,7 @@ func TestExeFilterRun(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command...")
-	if err := regolith.Run("dev", []string{}, true, "", false); err != nil {
+	if err := regolith.Run("dev", []string{}, true, "", false, false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	// TEST EVALUATION
@@ -125,7 +125,7 @@ func TestProfileFilterRun(t *testing.T) {
 	// THE TEST
 	// Invalid profile (shoud fail)
 	t.Log("Running invalid profile filter with circular dependencies (this should fail).")
-	err := regolith.Run("invalid_circular_profile_1", []string{}, true, "", false)
+	err := regolith.Run("invalid_circular_profile_1", []string{}, true, "", false, false, false)
 	if err == nil {
 		t.Fatal("'regolith run' didn't return an error after running" +
 			" a circular profile filter.")
@@ -134,7 +134,7 @@ func TestProfileFilterRun(t *testing.T) {
 	}
 	// Valid profile (should succeed)
 	t.Log("Running valid profile filter.")
-	err = regolith.Run("correct_nested_profile", []string{}, true, "", false)
+	err = regolith.Run("correct_nested_profile", []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}

--- a/test/pre_post_shell_os_specific_test.go
+++ b/test/pre_post_shell_os_specific_test.go
@@ -27,7 +27,7 @@ func TestPrePostShellCommandsOSSpecific(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing OS-specific preShell and postShell commands...")
-	if err := regolith.Run("default", nil, true, "", false); err != nil {
+	if err := regolith.Run("default", nil, true, "", false, false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/pre_post_shell_test.go
+++ b/test/pre_post_shell_test.go
@@ -27,7 +27,7 @@ func TestPrePostShellCommands(t *testing.T) {
 
 	// THE TEST
 	t.Log("Testing the 'regolith run' command with preShell and postShell...")
-	if err := regolith.Run("default", nil, true, "", false); err != nil {
+	if err := regolith.Run("default", nil, true, "", false, false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -38,7 +38,7 @@ func TestInstallAllAndRun(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("dev", []string{}, true, "", false, false, false)
+	err = regolith.Run("dev", []string{}, true, "", false, false, true)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/remote_filters_test.go
+++ b/test/remote_filters_test.go
@@ -38,7 +38,7 @@ func TestInstallAllAndRun(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("dev", []string{}, true, "", false)
+	err = regolith.Run("dev", []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}
@@ -78,7 +78,7 @@ func TestDataModifyRemoteFilter(t *testing.T) {
 	}
 
 	t.Log("Testing the 'regolith run' command...")
-	err = regolith.Run("default", []string{}, true, "", false)
+	err = regolith.Run("default", []string{}, true, "", false, false, false)
 	if err != nil {
 		t.Fatal("'regolith run' failed:", err)
 	}

--- a/test/size_time_check_optimization_method_test.go
+++ b/test/size_time_check_optimization_method_test.go
@@ -45,13 +45,12 @@ func TestSizeTimeCheckOptimizationCorectness(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	// THE TEST
-	// Enable the experiment
-	regolith.EnabledExperiments = append(regolith.EnabledExperiments, "size_time_check")
+	// Size time check is enabled by default
 
 	// Run the project
 	t.Log("Running Regolith...")
 
-	if err := regolith.Run("default", []string{}, true, "", false); err != nil {
+		if err := regolith.Run("default", []string{}, true, "", false, false, false); err != nil {
 		t.Fatal("'regolith run' failed:", err.Error())
 	}
 	// TEST EVALUATION
@@ -83,8 +82,7 @@ func TestSizeTimeCheckOptimizationSpeed(t *testing.T) {
 	os.Chdir(tmpDir)
 
 	// THE TEST
-	// Enable the experiment
-	regolith.EnabledExperiments = append(regolith.EnabledExperiments, "size_time_check")
+	// Size time check is enabled by default
 
 	// Run the project twice, the second run should be faster
 	runtimes := make([]time.Duration, 0)
@@ -94,7 +92,7 @@ func TestSizeTimeCheckOptimizationSpeed(t *testing.T) {
 
 		// Start the timer
 		start := time.Now()
-		if err := regolith.Run("default", []string{}, true, "", false); err != nil {
+	if err := regolith.Run("default", []string{}, true, "", false, false, false); err != nil {
 			t.Fatal("'regolith run' failed:", err.Error())
 		}
 		// Stop the timer


### PR DESCRIPTION
This PR was written completely by AI. At the moment of writing this comment, I have not reviewed any of it. It might be total garbage. Treat this as a PR from a complete stranger.



The AI's summary:
> This PR promotes the two long-standing experiments to proper CLI flags and fixes a bug in the process:
> 
> - **`symlink_export`** → `--symlink-export` flag on `run` and `watch` commands
> - **`size_time_check`** → enabled by default, with a `--disable-size-time-check` flag to opt out
> - The `--experiments` flag is removed (the experiment infrastructure is kept with an empty list for future use)
> 
> **Bug fix:** Previously, enabling symlink export would automatically trigger the size-time-check sync optimization (`SyncDirectories`) when copying source files to tmp, even when size-time-check was disabled. Now symlink export uses a regular copy with orphan cleanup (`Sync: true`) instead, and `SyncDirectories` is only used when size-time-check is explicitly enabled.
> 
> Both flags are passed through `RunContext` rather than stored as global variables.
