### PR TITLE
🤖 AI PR: Use "unified" $schema

### DIFF
--- a/regolith/config.go
+++ b/regolith/config.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const latestCompatibleVersion = "1.7.0"
+const latestCompatibleVersion = "1.8.0"
 
 const StandardLibraryUrl = "github.com/Bedrock-OSS/regolith-filters"
 const ConfigFilePath = "config.json"

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -29,7 +29,7 @@ func GetExportPaths(
 	if semver.Compare(vFormatVersion, "v1.4.0") < 0 {
 		bpPath, rpPath, err = getExportPathsV1_2_0(
 			exportTarget, bpName, rpName)
-	} else if semver.Compare(vFormatVersion, "v1.7.0") <= 0 {
+	} else if semver.Compare(vFormatVersion, "v1.8.0") <= 0 {
 		bpPath, rpPath, err = getExportPathsV1_4_0(
 			exportTarget, bpName, rpName)
 	} else {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -480,7 +480,7 @@ func Init(debug, force bool, env string) error {
 			ResourceFolder: "./packs/RP",
 		},
 		RegolithProject: RegolithProject{
-			FormatVersion:     "1.7.0",
+			FormatVersion:     "1.8.0",
 			DataPath:          "./packs/data",
 			FilterDefinitions: map[string]FilterInstaller{},
 			Profiles: map[string]Profile{
@@ -503,7 +503,7 @@ func Init(debug, force bool, env string) error {
 	// Add the schema property, this is a little hacky
 	rawJsonData := make(map[string]any, 0)
 	json.Unmarshal(jsonBytes, &rawJsonData)
-	rawJsonData["$schema"] = "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.7.json"
+	rawJsonData["$schema"] = "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/unified.json"
 	jsonBytes, _ = json.MarshalIndent(rawJsonData, "", "\t")
 
 	err = os.WriteFile(ConfigFilePath, jsonBytes, 0644)

--- a/test/testdata/fresh_project/config.json
+++ b/test/testdata/fresh_project/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/v1.7.json",
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/unified.json",
 	"author": "Your name",
 	"name": "Project name",
 	"packs": {
@@ -9,7 +9,7 @@
 	"regolith": {
 		"dataPath": "./packs/data",
 		"filterDefinitions": {},
-		"formatVersion": "1.7.0",
+		"formatVersion": "1.8.0",
 		"profiles": {
 			"default": {
 				"export": {


### PR DESCRIPTION
Should be good nothing special here.

This PR switches from the specific version in $schema in generated `config.json` files to the unified version. It also enables the 1.8.0 schemas support for the current version of regolith.