### PR TITLE
WIP: Multi-pack support

### DIFF
--- a/regolith/config.go
+++ b/regolith/config.go
@@ -22,7 +22,7 @@ const GitIgnore = "/build\n/.regolith"
 type Config struct {
 	Name            string `json:"name,omitempty"`
 	Author          string `json:"author,omitempty"`
-	Packs           `json:"packs,omitzero"`
+	Packs           Packs  `json:"packs,omitzero"`
 	RegolithProject `json:"regolith,omitzero"`
 }
 
@@ -157,6 +157,36 @@ func SortPacksForTest(packs []Pack) { sortPacks(packs) }
 
 var behaviorPackKeyRe = regexp.MustCompile(`^BP([1-9][0-9]*)?$`)
 var resourcePackKeyRe = regexp.MustCompile(`^RP([1-9][0-9]*)?$`)
+
+// MarshalJSON writes the single-pack default (one "BP" and/or one "RP") as the
+// legacy string form for backward compatibility, and the multi-pack form as
+// name->path maps.
+func (p Packs) MarshalJSON() ([]byte, error) {
+	obj := map[string]any{}
+	marshalPackList(obj, p.BehaviorPacks, "BP", "behaviorPack", "behaviorPacks")
+	marshalPackList(obj, p.ResourcePacks, "RP", "resourcePack", "resourcePacks")
+	return json.Marshal(obj)
+}
+
+func marshalPackList(
+	obj map[string]any, packs []Pack, primaryName, singularKey, pluralKey string,
+) {
+	isSingleDefault := len(packs) == 1 && packs[0].Name == primaryName
+	if isSingleDefault {
+		if packs[0].Source != "" {
+			obj[singularKey] = packs[0].Source
+		}
+		return
+	}
+	if len(packs) == 0 {
+		return
+	}
+	m := make(map[string]string, len(packs))
+	for _, pack := range packs {
+		m[pack.Name] = pack.Source
+	}
+	obj[pluralKey] = m
+}
 
 // RegolithProject is a part of "config.json" with the regolith namespace
 // within the Minecraft Project Schema

--- a/regolith/config.go
+++ b/regolith/config.go
@@ -3,12 +3,15 @@ package regolith
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
 
 	"github.com/Bedrock-OSS/go-burrito/burrito"
 	"golang.org/x/mod/semver"
 )
 
-const latestCompatibleVersion = "1.8.0"
+const latestCompatibleVersion = "1.9.0"
 
 const StandardLibraryUrl = "github.com/Bedrock-OSS/regolith-filters"
 const ConfigFilePath = "config.json"
@@ -69,12 +72,91 @@ func (et *ExportTargets) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Packs is a part of "config.json" that points to the source behavior and
-// resource packs.
-type Packs struct {
-	BehaviorFolder string `json:"behaviorPack,omitempty"`
-	ResourceFolder string `json:"resourcePack,omitempty"`
+// Pack is a single source pack mapped into the tmp working directory under a
+// folder named Name ("BP", "BP1", "RP", ...). Source may be empty when the
+// pack has no source on disk and is produced by filters.
+type Pack struct {
+	Name   string
+	Source string
 }
+
+// Packs is a part of "config.json" that points to the source behavior and
+// resource packs. The first behavior pack is always named "BP" and the first
+// resource pack "RP" (the primary packs the filters operate on).
+type Packs struct {
+	BehaviorPacks []Pack
+	ResourcePacks []Pack
+}
+
+// IsZero lets json:",omitzero" omit an unset Packs value.
+func (p Packs) IsZero() bool {
+	return len(p.BehaviorPacks) == 0 && len(p.ResourcePacks) == 0
+}
+
+// PrimaryBehaviorSource returns the source path of the "BP" pack, or "".
+func (p Packs) PrimaryBehaviorSource() string {
+	return primaryPackSource(p.BehaviorPacks, "BP")
+}
+
+// PrimaryResourceSource returns the source path of the "RP" pack, or "".
+func (p Packs) PrimaryResourceSource() string {
+	return primaryPackSource(p.ResourcePacks, "RP")
+}
+
+func primaryPackSource(packs []Pack, primaryName string) string {
+	for _, pack := range packs {
+		if pack.Name == primaryName {
+			return pack.Source
+		}
+	}
+	return ""
+}
+
+// packSuffix returns the numeric suffix of a pack name ("" for "BP", "1" for
+// "BP1", "12" for "BP12").
+func packSuffix(name string) string {
+	i := 0
+	for i < len(name) && (name[i] < '0' || name[i] > '9') {
+		i++
+	}
+	return name[i:]
+}
+
+// packIndex returns the numeric index of a pack name (0 for the bare "BP"/"RP").
+func packIndex(name string) int {
+	suffix := packSuffix(name)
+	if suffix == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// sortPacks orders packs by numeric index so the primary ("BP"/"RP") comes
+// first, then "BP1", "BP2", ...
+func sortPacks(packs []Pack) {
+	sort.SliceStable(packs, func(i, j int) bool {
+		return packIndex(packs[i].Name) < packIndex(packs[j].Name)
+	})
+}
+
+func hasPackNamed(packs []Pack, name string) bool {
+	for _, pack := range packs {
+		if pack.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// SortPacksForTest exposes sortPacks for external tests.
+func SortPacksForTest(packs []Pack) { sortPacks(packs) }
+
+var behaviorPackKeyRe = regexp.MustCompile(`^BP([1-9][0-9]*)?$`)
+var resourcePackKeyRe = regexp.MustCompile(`^RP([1-9][0-9]*)?$`)
 
 // RegolithProject is a part of "config.json" with the regolith namespace
 // within the Minecraft Project Schema
@@ -101,14 +183,26 @@ func ConfigFromObject(obj map[string]any) (*Config, error) {
 		return nil, burrito.WrappedErrorf(jsonPathMissingError, "author")
 	}
 	result.Author = author
+	// Read formatVersion early so packs parsing can gate the multi-pack map
+	// form. Full validation of formatVersion still happens in
+	// RegolithProjectFromObject below.
+	formatVersion := "1.2.0"
+	if regolithObj, ok := obj["regolith"].(map[string]any); ok {
+		if fv, ok := regolithObj["formatVersion"].(string); ok {
+			formatVersion = fv
+		}
+	}
 	// Packs
 	if packs, ok := obj["packs"]; ok {
 		packs, ok := packs.(map[string]any)
 		if !ok {
 			return nil, burrito.WrappedErrorf(jsonPathTypeError, "packs", "object")
 		}
-		// Packs can be empty, no need to check for errors
-		result.Packs = PacksFromObject(packs)
+		parsedPacks, err := PacksFromObject(packs, formatVersion)
+		if err != nil {
+			return nil, burrito.WrapErrorf(err, jsonPropertyParseError, "packs")
+		}
+		result.Packs = parsedPacks
 	} else {
 		return nil, burrito.WrappedErrorf(jsonPathMissingError, "packs")
 	}
@@ -130,16 +224,78 @@ func ConfigFromObject(obj map[string]any) (*Config, error) {
 	return result, nil
 }
 
-// ProfileFromObject creates a "Profile" object from map[string]interface{}
-func PacksFromObject(obj map[string]any) Packs {
+// PacksFromObject creates a "Packs" object from map[string]interface{}. The
+// formatVersion gates the multi-pack map form: it is only allowed for
+// formatVersion >= 1.9.0. Older versions accept only the singular string form.
+func PacksFromObject(obj map[string]any, formatVersion string) (Packs, error) {
 	result := Packs{}
-	// BehaviorPack
-	behaviorPack, _ := obj["behaviorPack"].(string)
-	result.BehaviorFolder = behaviorPack
-	// ResourcePack
-	resourcePack, _ := obj["resourcePack"].(string)
-	result.ResourceFolder = resourcePack
-	return result
+	multiPackSupported := semver.Compare("v"+formatVersion, "v1.9.0") >= 0
+
+	behaviorPacks, err := parsePackField(
+		obj, "behaviorPack", "behaviorPacks", "BP",
+		behaviorPackKeyRe, multiPackSupported)
+	if err != nil {
+		return result, burrito.PassError(err)
+	}
+	result.BehaviorPacks = behaviorPacks
+
+	resourcePacks, err := parsePackField(
+		obj, "resourcePack", "resourcePacks", "RP",
+		resourcePackKeyRe, multiPackSupported)
+	if err != nil {
+		return result, burrito.PassError(err)
+	}
+	result.ResourcePacks = resourcePacks
+	return result, nil
+}
+
+// parsePackField parses one pack type. It accepts the singular string form
+// (single primary pack) or the plural map form (multiple packs, >=1.9.0). The
+// primary pack (primaryName) is always present in the returned slice.
+func parsePackField(
+	obj map[string]any,
+	singularKey, pluralKey, primaryName string,
+	keyRe *regexp.Regexp,
+	multiPackSupported bool,
+) ([]Pack, error) {
+	_, hasPlural := obj[pluralKey]
+	_, hasSingular := obj[singularKey]
+
+	if hasPlural {
+		if !multiPackSupported {
+			return nil, burrito.WrappedErrorf(multiPackVersionError, pluralKey)
+		}
+		if hasSingular {
+			return nil, burrito.WrappedErrorf(
+				packsMixedFormError, singularKey, pluralKey)
+		}
+		packMap, ok := obj[pluralKey].(map[string]any)
+		if !ok {
+			return nil, burrito.WrappedErrorf(jsonPropertyTypeError, pluralKey, "object")
+		}
+		packs := make([]Pack, 0, len(packMap))
+		for name, src := range packMap {
+			if !keyRe.MatchString(name) {
+				return nil, burrito.WrappedErrorf(packKeyInvalidError, name, pluralKey)
+			}
+			srcStr, ok := src.(string)
+			if !ok {
+				return nil, burrito.WrappedErrorf(
+					jsonPathTypeError, pluralKey+"->"+name, "string")
+			}
+			packs = append(packs, Pack{Name: name, Source: srcStr})
+		}
+		if !hasPackNamed(packs, primaryName) {
+			packs = append(packs, Pack{Name: primaryName, Source: ""})
+		}
+		sortPacks(packs)
+		return packs, nil
+	}
+
+	// Singular string form (legacy and >=1.9.0 sugar). The primary pack always
+	// exists, even when the source is empty/missing.
+	src, _ := obj[singularKey].(string)
+	return []Pack{{Name: primaryName, Source: src}}, nil
 }
 
 // RegolithProjectFromObject creates a "RegolithProject" object from

--- a/regolith/config.go
+++ b/regolith/config.go
@@ -30,19 +30,19 @@ type Config struct {
 // for a profile, which denotes where compiled files will go.
 // When editing, adjust ExportTargetFromObject function as well.
 type ExportTarget struct {
-	Target    string `json:"target,omitempty"` // The mode of exporting. "develop" or "exact"
-	RpPath    string `json:"rpPath,omitempty"` // Relative or absolute path to resource pack for "exact" export target
-	BpPath    string `json:"bpPath,omitempty"` // Relative or absolute path to resource pack for "exact" export target
-	RpName    string `json:"rpName,omitempty"`
-	BpName    string `json:"bpName,omitempty"`
-	WorldName string `json:"worldName,omitempty"`
-	WorldPath string `json:"worldPath,omitempty"`
-	ReadOnly  bool   `json:"readOnly"`        // Whether the exported files should be read-only
-	Build     string `json:"build,omitempty"` // The type of Minecraft build for the 'develop'
-	BpNames map[string]string `json:"bpNames,omitempty"` // per-pack name overrides (>=1.9.0)
-	RpNames map[string]string `json:"rpNames,omitempty"`
-	BpPaths map[string]string `json:"bpPaths,omitempty"` // per-pack "exact" paths (>=1.9.0)
-	RpPaths map[string]string `json:"rpPaths,omitempty"`
+	Target    string            `json:"target,omitempty"`    // The mode of exporting. "develop" or "exact"
+	RpPath    string            `json:"rpPath,omitempty"`    // Relative or absolute path to resource pack for "exact" export target
+	BpPath    string            `json:"bpPath,omitempty"`    // Relative or absolute path to behavior pack for "exact" export target
+	RpName    string            `json:"rpName,omitempty"`
+	BpName    string            `json:"bpName,omitempty"`
+	WorldName string            `json:"worldName,omitempty"`
+	WorldPath string            `json:"worldPath,omitempty"`
+	ReadOnly  bool              `json:"readOnly"`            // Whether the exported files should be read-only
+	Build     string            `json:"build,omitempty"`     // The type of Minecraft build for the 'develop'
+	BpNames   map[string]string `json:"bpNames,omitempty"`   // per-pack name overrides (>=1.9.0)
+	RpNames   map[string]string `json:"rpNames,omitempty"`
+	BpPaths   map[string]string `json:"bpPaths,omitempty"`   // per-pack "exact" paths (>=1.9.0)
+	RpPaths   map[string]string `json:"rpPaths,omitempty"`
 }
 
 // ExportTargets is the config representation of a profile's "export" value.

--- a/regolith/config.go
+++ b/regolith/config.go
@@ -39,6 +39,10 @@ type ExportTarget struct {
 	WorldPath string `json:"worldPath,omitempty"`
 	ReadOnly  bool   `json:"readOnly"`        // Whether the exported files should be read-only
 	Build     string `json:"build,omitempty"` // The type of Minecraft build for the 'develop'
+	BpNames map[string]string `json:"bpNames,omitempty"` // per-pack name overrides (>=1.9.0)
+	RpNames map[string]string `json:"rpNames,omitempty"`
+	BpPaths map[string]string `json:"bpPaths,omitempty"` // per-pack "exact" paths (>=1.9.0)
+	RpPaths map[string]string `json:"rpPaths,omitempty"`
 }
 
 // ExportTargets is the config representation of a profile's "export" value.
@@ -500,5 +504,26 @@ func ExportTargetFromObject(obj map[string]any) (ExportTarget, error) {
 	// Build - can be empty
 	build, _ := obj["build"].(string)
 	result.Build = build
+	// Per-pack overrides (used only for formatVersion >= 1.9.0 multi-pack).
+	result.BpNames = stringMapFromObject(obj, "bpNames")
+	result.RpNames = stringMapFromObject(obj, "rpNames")
+	result.BpPaths = stringMapFromObject(obj, "bpPaths")
+	result.RpPaths = stringMapFromObject(obj, "rpPaths")
 	return result, nil
+}
+
+// stringMapFromObject reads a JSON object value into a map[string]string,
+// returning nil when the key is absent or not an object.
+func stringMapFromObject(obj map[string]any, key string) map[string]string {
+	raw, ok := obj[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+	result := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			result[k] = s
+		}
+	}
+	return result
 }

--- a/regolith/config.go
+++ b/regolith/config.go
@@ -97,25 +97,6 @@ func (p Packs) IsZero() bool {
 	return len(p.BehaviorPacks) == 0 && len(p.ResourcePacks) == 0
 }
 
-// PrimaryBehaviorSource returns the source path of the "BP" pack, or "".
-func (p Packs) PrimaryBehaviorSource() string {
-	return primaryPackSource(p.BehaviorPacks, "BP")
-}
-
-// PrimaryResourceSource returns the source path of the "RP" pack, or "".
-func (p Packs) PrimaryResourceSource() string {
-	return primaryPackSource(p.ResourcePacks, "RP")
-}
-
-func primaryPackSource(packs []Pack, primaryName string) string {
-	for _, pack := range packs {
-		if pack.Name == primaryName {
-			return pack.Source
-		}
-	}
-	return ""
-}
-
 // packSuffix returns the numeric suffix of a pack name ("" for "BP", "1" for
 // "BP1", "12" for "BP12").
 func packSuffix(name string) string {

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -248,6 +248,19 @@ const (
 		"Version in config: %s\n" +
 		"Latest compatible version: %s"
 
+	// Error when a packs map is used on a formatVersion that predates 1.9.0.
+	multiPackVersionError = "Multiple packs require formatVersion 1.9.0 or " +
+		"higher.\nJSON property: %s"
+
+	// Error when both the singular and plural pack forms are present.
+	packsMixedFormError = "Cannot use both %q and %q in the \"packs\" object. " +
+		"Use only one of them."
+
+	// Error for an invalid pack name key in the packs map.
+	packKeyInvalidError = "Invalid pack name %q in %q.\n" +
+		"Pack names must be \"BP\"/\"RP\" or \"BP1\", \"BP2\", ... " +
+		"(\"BP0\"/\"RP0\" are not allowed)."
+
 	// Error used when createDirLink fails
 	createDirLinkError = "Failed to create directory link.\nSource: %s\nTarget: %s"
 

--- a/regolith/errors.go
+++ b/regolith/errors.go
@@ -295,4 +295,8 @@ const (
 	userSettingIncorrectKeyUseError = "Cannot use <key> with non-map property."
 
 	getRunnerError = "Failed to get the path to filter runner."
+
+	// Error when an "exact" export target has no path for a given pack.
+	exactPathMissingError = "No \"exact\" export path configured for pack %q.\n" +
+		"Add it to the %q map of the export target."
 )

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -40,6 +40,115 @@ func GetExportPaths(
 	return
 }
 
+// GetPackExportPath returns the export destination for a single pack. For
+// formatVersion < 1.9.0 (single pack only) it delegates to the legacy
+// GetExportPaths so behavior is unchanged. For >=1.9.0 it resolves a
+// destination per pack using the 1.4.0-style com.mojang lookup.
+func GetPackExportPath(
+	exportTarget ExportTarget, ctx RunContext, pack Pack, packType string,
+) (string, error) {
+	if semver.Compare("v"+ctx.Config.FormatVersion, "v1.9.0") < 0 {
+		bpPath, rpPath, err := GetExportPaths(exportTarget, ctx)
+		if err != nil {
+			return "", burrito.PassError(err)
+		}
+		if packType == "bp" {
+			return bpPath, nil
+		}
+		return rpPath, nil
+	}
+	name, err := GetExportName(exportTarget, ctx, pack, packType)
+	if err != nil {
+		return "", burrito.PassError(err)
+	}
+	switch exportTarget.Target {
+	case "development":
+		comMojang, err := FindMojangDir(exportTarget.Build, PacksPath)
+		if err != nil {
+			return "", burrito.PassError(err)
+		}
+		subDir := "development_behavior_packs"
+		if packType == "rp" {
+			subDir = "development_resource_packs"
+		}
+		return comMojang + "/" + subDir + "/" + name, nil
+	case "world":
+		return getWorldPackExportPath(exportTarget, packType, name)
+	case "exact":
+		return getExactPackExportPath(exportTarget, pack, packType)
+	case "local":
+		return "build/" + name + "/", nil
+	case "none":
+		return "", nil
+	default:
+		return "", burrito.WrappedErrorf(
+			"Export target %q is not valid", exportTarget.Target)
+	}
+}
+
+func getWorldPackExportPath(
+	exportTarget ExportTarget, packType, name string,
+) (string, error) {
+	subDir := "behavior_packs"
+	if packType == "rp" {
+		subDir = "resource_packs"
+	}
+	if exportTarget.WorldPath != "" {
+		if exportTarget.WorldName != "" {
+			return "", burrito.WrappedError(
+				"Using both \"worldName\" and \"worldPath\" is not allowed.")
+		}
+		wPath, err := ResolvePath(exportTarget.WorldPath)
+		if err != nil {
+			return "", burrito.WrapError(err, "Failed to resolve world path.")
+		}
+		return filepath.Join(wPath, subDir, name), nil
+	}
+	if exportTarget.WorldName != "" {
+		dir, err := FindMojangDir(exportTarget.Build, WorldPath)
+		if err != nil {
+			return "", burrito.WrapError(
+				err, "Failed to find \"com.mojang\" directory.")
+		}
+		worlds, err := ListWorlds(dir)
+		if err != nil {
+			return "", burrito.WrapError(err, "Failed to list worlds.")
+		}
+		for _, world := range worlds {
+			if world.Name == exportTarget.WorldName {
+				return filepath.Join(world.Path, subDir, name), nil
+			}
+		}
+		return "", burrito.WrappedErrorf(
+			"Failed to find the world.\nWorld name: %s", exportTarget.WorldName)
+	}
+	return "", burrito.WrappedError(
+		"The \"world\" export target requires either a \"worldName\" or " +
+			"\"worldPath\" property")
+}
+
+func getExactPackExportPath(
+	exportTarget ExportTarget, pack Pack, packType string,
+) (string, error) {
+	pathsMap := exportTarget.BpPaths
+	singlePath := exportTarget.BpPath
+	primaryName := "BP"
+	pluralKey := "bpPaths"
+	if packType == "rp" {
+		pathsMap = exportTarget.RpPaths
+		singlePath = exportTarget.RpPath
+		primaryName = "RP"
+		pluralKey = "rpPaths"
+	}
+	if raw, ok := pathsMap[pack.Name]; ok {
+		return ResolvePath(raw)
+	}
+	if pack.Name == primaryName && singlePath != "" {
+		return ResolvePath(singlePath)
+	}
+	return "", burrito.WrappedErrorf(exactPathMissingError, pack.Name, pluralKey)
+}
+
 func FindMojangDir(build string, pathType ComMojangPathType) (string, error) {
 	switch build {
 	case "standard":

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -723,9 +723,10 @@ func exportProjectData(profile Profile, ctx RunContext) error {
 	return nil
 }
 
-// InplaceExportProject copies the files from the tmp paths (tmp/BP, tmp/RP and
-// tmp/data) into the project's source files. It's used by the "regolith apply-filter"
-// command. This operation is destructive and cannot be undone.
+// InplaceExportProject copies the files from every pack's tmp folder
+// (tmp/BP, tmp/BP1, …, tmp/RP, … and tmp/data) back into the project's source
+// files. It's used by the "regolith apply-filter" command. This operation is
+// destructive and cannot be undone.
 func InplaceExportProject(
 	config *Config, dotRegolithPath string,
 ) (err error) {

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -227,6 +227,38 @@ func GetExportNames(exportTarget ExportTarget, ctx RunContext) (bpName string, r
 	return
 }
 
+// GetExportName returns the export pack name for a single pack. Resolution
+// order: per-pack override map (bpNames/rpNames), then the singular
+// bpName/rpName for the primary pack, then the default
+// "<projectName>_bp<index>" / "<projectName>_rp<index>".
+func GetExportName(
+	exportTarget ExportTarget, ctx RunContext, pack Pack, packType string,
+) (string, error) {
+	namesMap := exportTarget.BpNames
+	singleName := exportTarget.BpName
+	primaryName := "BP"
+	if packType == "rp" {
+		namesMap = exportTarget.RpNames
+		singleName = exportTarget.RpName
+		primaryName = "RP"
+	}
+	if expr, ok := namesMap[pack.Name]; ok && expr != "" {
+		name, err := EvalString(expr, ctx)
+		if err != nil {
+			return "", burrito.WrapError(err, "Failed to evaluate pack name.")
+		}
+		return name, nil
+	}
+	if pack.Name == primaryName && singleName != "" {
+		name, err := EvalString(singleName, ctx)
+		if err != nil {
+			return "", burrito.WrapError(err, "Failed to evaluate pack name.")
+		}
+		return name, nil
+	}
+	return ctx.Config.Name + "_" + strings.ToLower(packType) + packSuffix(pack.Name), nil
+}
+
 type resolvedExportTarget struct {
 	target ExportTarget
 	bpPath string

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -368,10 +368,15 @@ func GetExportName(
 	return ctx.Config.Name + "_" + strings.ToLower(packType) + packSuffix(pack.Name), nil
 }
 
+type resolvedPackExport struct {
+	pack     Pack
+	packType string // "bp" or "rp"
+	destPath string
+}
+
 type resolvedExportTarget struct {
-	target ExportTarget
-	bpPath string
-	rpPath string
+	target      ExportTarget
+	packExports []resolvedPackExport
 }
 
 func normalizeExportPathForCollision(path string) (string, error) {
@@ -419,35 +424,48 @@ func checkExportPathCollision(seen map[string]string, path, label string) error 
 	return nil
 }
 
-// ExportProject copies files from the tmp paths (tmp/BP and tmp/RP) into
-// the project's export targets. The paths are generated with GetExportPaths.
+// ExportProject copies files from the tmp pack folders (tmp/BP, tmp/BP1,
+// tmp/RP, ...) into the project's export targets. Destinations are generated
+// per pack with GetPackExportPath.
 func ExportProject(ctx RunContext) error {
 	MeasureStart("Export - GetExportPaths")
 	profile, err := ctx.GetProfile()
 	if err != nil {
 		return burrito.WrapError(err, runContextGetProfileError)
 	}
-	// Resolve all non-"none" targets before modifying any export path. This
-	// keeps failure atomic when a later target has an invalid path or unsafe
-	// existing files.
+	// Resolve all non-"none" targets (and all their packs) before modifying any
+	// export path, so failure stays atomic.
 	var activeTargets []resolvedExportTarget
 	seenExportPaths := make(map[string]string)
 	for i, exportTarget := range profile.activeExportTargets() {
-		bpPath, rpPath, err := GetExportPaths(exportTarget, ctx)
-		if err != nil {
-			return burrito.WrapError(err, getExportPathsError)
+		var packExports []resolvedPackExport
+		resolvePack := func(pack Pack, packType string) error {
+			destPath, err := GetPackExportPath(exportTarget, ctx, pack, packType)
+			if err != nil {
+				return burrito.WrapError(err, getExportPathsError)
+			}
+			label := fmt.Sprintf(
+				"export target %d (%s) %s pack %q: %s",
+				i+1, exportTarget.Target, packType, pack.Name, destPath)
+			if err := checkExportPathCollision(seenExportPaths, destPath, label); err != nil {
+				return burrito.PassError(err)
+			}
+			packExports = append(packExports, resolvedPackExport{pack, packType, destPath})
+			return nil
 		}
-		targetLabel := fmt.Sprintf("export target %d (%s)", i+1, exportTarget.Target)
-		if err := checkExportPathCollision(seenExportPaths, bpPath, targetLabel+" behavior pack: "+bpPath); err != nil {
-			return burrito.PassError(err)
+		for _, pack := range ctx.Config.Packs.BehaviorPacks {
+			if err := resolvePack(pack, "bp"); err != nil {
+				return burrito.PassError(err)
+			}
 		}
-		if err := checkExportPathCollision(seenExportPaths, rpPath, targetLabel+" resource pack: "+rpPath); err != nil {
-			return burrito.PassError(err)
+		for _, pack := range ctx.Config.Packs.ResourcePacks {
+			if err := resolvePack(pack, "rp"); err != nil {
+				return burrito.PassError(err)
+			}
 		}
 		activeTargets = append(activeTargets, resolvedExportTarget{
-			target: exportTarget,
-			bpPath: bpPath,
-			rpPath: rpPath,
+			target:      exportTarget,
+			packExports: packExports,
 		})
 	}
 	if len(activeTargets) == 0 {
@@ -455,53 +473,49 @@ func ExportProject(ctx RunContext) error {
 		return nil
 	}
 	dotRegolithPath := ctx.DotRegolithPath
-	useSymlink := ctx.SymlinkExport && len(activeTargets) == 1
+	isSinglePack := len(ctx.Config.Packs.BehaviorPacks) == 1 && len(ctx.Config.Packs.ResourcePacks) == 1
+	useSymlink := ctx.SymlinkExport && len(activeTargets) == 1 && isSinglePack
 	editedFiles := LoadEditedFiles(dotRegolithPath)
 	if !useSymlink && !ctx.UnsafeMode {
 		MeasureStart("Export - CheckDeletionSafety")
 		for _, exportTarget := range activeTargets {
-			err = editedFiles.CheckDeletionSafety(exportTarget.rpPath, exportTarget.bpPath)
-			if err != nil {
-				return burrito.WrapErrorf(
-					err, checkDeletionSafetyError, exportTarget.rpPath, exportTarget.bpPath)
+			for _, pe := range exportTarget.packExports {
+				if err := editedFiles.CheckPackDeletionSafety(pe.packType, pe.destPath); err != nil {
+					return burrito.WrapErrorf(
+						err, checkDeletionSafetyError, pe.destPath, pe.destPath)
+				}
 			}
 		}
 	}
 
 	for i, exportTarget := range activeTargets {
-		// Symlink export already placed files for the only active target.
 		if useSymlink && i == 0 {
 			Logger.Debugf("Symlink export is enabled. Skipping RP and BP export.")
-		} else {
-			// Move is only safe when there is exactly one active target
-			// and symlink export is off, since tmp/ is the sole source and
-			// moving from a symlinked tmp would destroy the first target.
-			canMove := len(activeTargets) == 1 && !useSymlink
-			err = exportProjectRpAndBp(
-				exportTarget.target, exportTarget.rpPath, exportTarget.bpPath,
-				ctx, canMove)
-			if err != nil {
-				return burrito.PassError(err)
-			}
+			continue
+		}
+		// Move is only safe when there is exactly one active target and symlink
+		// export is off, since each tmp pack folder is the sole source.
+		canMove := len(activeTargets) == 1 && !useSymlink
+		if err := exportTargetPacks(exportTarget, ctx, canMove); err != nil {
+			return burrito.PassError(err)
 		}
 	}
 	// Export data once (not per target)
 	MeasureStart("Export - ExportData")
-	err = exportProjectData(profile, ctx)
-	if err != nil {
+	if err := exportProjectData(profile, ctx); err != nil {
 		return burrito.PassError(err)
 	}
 	MeasureStart("Export - EditedFiles.UpdateFromPaths")
 	for _, exportTarget := range activeTargets {
-		err = editedFiles.UpdateFromPaths(exportTarget.rpPath, exportTarget.bpPath)
-		if err != nil {
-			return burrito.WrapError(
-				err,
-				"Failed to create a list of files edited by this 'regolith run'")
+		for _, pe := range exportTarget.packExports {
+			if err := editedFiles.UpdatePackFromPath(pe.packType, pe.destPath); err != nil {
+				return burrito.WrapError(
+					err,
+					"Failed to create a list of files edited by this 'regolith run'")
+			}
 		}
 	}
-	err = editedFiles.Dump(dotRegolithPath)
-	if err != nil {
+	if err := editedFiles.Dump(dotRegolithPath); err != nil {
 		return burrito.WrapError(err, updatedFilesDumpError)
 	}
 	MeasureStart("Export - Remove Empty Export Paths")
@@ -509,14 +523,13 @@ func ExportProject(ctx RunContext) error {
 		if useSymlink && i == 0 {
 			continue
 		}
-		for _, packPath := range []string{exportTarget.rpPath, exportTarget.bpPath} {
-			pathEmpty, _ := IsDirEmpty(packPath)
+		for _, pe := range exportTarget.packExports {
+			pathEmpty, _ := IsDirEmpty(pe.destPath)
 			if pathEmpty {
-				if err := os.Remove(packPath); err != nil {
+				if err := os.Remove(pe.destPath); err != nil {
 					Logger.Warnf(
 						"Failed to remove empty pack directory.\n"+
-							"Path: %s\n"+
-							"Error: %v", packPath, err)
+							"Path: %s\nError: %v", pe.destPath, err)
 				}
 			}
 		}
@@ -525,62 +538,48 @@ func ExportProject(ctx RunContext) error {
 	return nil
 }
 
-// exportProjectRpAndBp is a helper function for ExportProject. It exports the
-// 'rp' and 'bp' folders to the target location. Moving is only safe for a
-// single active target without symlink export, since the tmp source must remain
-// intact for additional targets.
-func exportProjectRpAndBp(exportTarget ExportTarget, rpPath, bpPath string, ctx RunContext, allowMove bool) error {
+// exportTargetPacks exports every pack of a resolved target from its tmp folder
+// to its destination. Moving is only allowed for a single active target without
+// symlink export, so the tmp source stays intact for additional targets.
+func exportTargetPacks(rt resolvedExportTarget, ctx RunContext, allowMove bool) error {
 	dotRegolithPath := ctx.DotRegolithPath
-
-	var err error
-	if ctx.DisableSizeTimeCheck {
-		MeasureStart("Export - Clean")
-		if err := removeJunctionSafe(bpPath); err != nil {
-			return burrito.WrapErrorf(
-				err, "Failed to clear behavior pack from build path %q.\n"+
-					"Are user permissions correct?", bpPath)
-		}
-		if err := removeJunctionSafe(rpPath); err != nil {
-			return burrito.WrapErrorf(
-				err, "Failed to clear resource pack from build path %q.\n"+
-					"Are user permissions correct?", rpPath)
-		}
-	}
-	MeasureStart("Export - MoveOrCopy")
 	absWorkingDir, err := GetAbsoluteWorkingDirectory(dotRegolithPath)
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
-	var wg sync.WaitGroup
-	packsData := []struct {
-		packPath     string
-		subpathInTmp string
-		packType     string
-	}{
-		{bpPath, "BP", "behavior"},
-		{rpPath, "RP", "resource"},
+	if ctx.DisableSizeTimeCheck {
+		MeasureStart("Export - Clean")
+		for _, pe := range rt.packExports {
+			if err := removeJunctionSafe(pe.destPath); err != nil {
+				return burrito.WrapErrorf(
+					err, "Failed to clear %s pack from build path %q.\n"+
+						"Are user permissions correct?", pe.packType, pe.destPath)
+			}
+		}
 	}
-	errChan := make(chan error, len(packsData))
-	for _, packData := range packsData {
-		packPath, subpathInTmp, packType := packData.packPath, packData.subpathInTmp, packData.packType
+	MeasureStart("Export - MoveOrCopy")
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(rt.packExports))
+	for _, pe := range rt.packExports {
+		pe := pe
+		source := filepath.Join(absWorkingDir, pe.pack.Name)
 		wg.Go(func() {
-			Logger.Infof("Exporting %s pack to \"%s\".", packType, packPath)
+			Logger.Infof("Exporting %s pack %q to \"%s\".", pe.packType, pe.pack.Name, pe.destPath)
 			var e error
 			if !ctx.DisableSizeTimeCheck {
-				e = SyncDirectories(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly)
+				e = SyncDirectories(source, pe.destPath, rt.target.ReadOnly)
 			} else if allowMove {
-				e = MoveOrCopy(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly, true)
+				e = MoveOrCopy(source, pe.destPath, rt.target.ReadOnly, true)
 			} else {
-				e = copyExportPath(filepath.Join(absWorkingDir, subpathInTmp), packPath, exportTarget.ReadOnly)
+				e = copyExportPath(source, pe.destPath, rt.target.ReadOnly)
 			}
 			if e != nil {
-				errChan <- burrito.WrapErrorf(e, "Failed to export %s pack.", packType)
+				errChan <- burrito.WrapErrorf(e, "Failed to export %s pack %q.", pe.packType, pe.pack.Name)
 				return
 			}
 			errChan <- nil
 		})
 	}
-
 	wg.Wait()
 	close(errChan)
 	for e := range errChan {

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -617,7 +617,7 @@ func InplaceExportProject(
 	}()
 	// Delete RP, BP and data before replacing them with files from tmp
 	deleteDirs := []string{
-		config.PrimaryResourceSource(), config.PrimaryBehaviorSource(), config.DataPath}
+		config.Packs.PrimaryResourceSource(), config.Packs.PrimaryBehaviorSource(), config.DataPath}
 	for _, deleteDir := range deleteDirs {
 		if deleteDir != "" {
 			err = revertibleOps.Delete(deleteDir)
@@ -634,8 +634,8 @@ func InplaceExportProject(
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
 	moveFiles := [][2]string{
-		{filepath.Join(absWorkingDir, "RP"), config.PrimaryResourceSource()},
-		{filepath.Join(absWorkingDir, "BP"), config.PrimaryBehaviorSource()},
+		{filepath.Join(absWorkingDir, "RP"), config.Packs.PrimaryResourceSource()},
+		{filepath.Join(absWorkingDir, "BP"), config.Packs.PrimaryBehaviorSource()},
 		{filepath.Join(absWorkingDir, "data"), config.DataPath},
 	}
 	for _, moveFile := range moveFiles {

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -755,38 +755,57 @@ func InplaceExportProject(
 			}
 		}
 	}()
-	// Delete RP, BP and data before replacing them with files from tmp
-	deleteDirs := []string{
-		config.Packs.PrimaryResourceSource(), config.Packs.PrimaryBehaviorSource(), config.DataPath}
-	for _, deleteDir := range deleteDirs {
-		if deleteDir != "" {
-			err = revertibleOps.Delete(deleteDir)
-			if err != nil {
-				err = burrito.WrapErrorf(
-					err, updateSourceFilesError, deleteDir)
-				return err // Overwritten by defer
-			}
+	// Delete every pack source and data before replacing them with files from
+	// tmp.
+	var deleteDirs []string
+	for _, pack := range config.Packs.BehaviorPacks {
+		if pack.Source != "" {
+			deleteDirs = append(deleteDirs, pack.Source)
 		}
 	}
-	// Move files from tmp to RP, BP and data
+	for _, pack := range config.Packs.ResourcePacks {
+		if pack.Source != "" {
+			deleteDirs = append(deleteDirs, pack.Source)
+		}
+	}
+	if config.DataPath != "" {
+		deleteDirs = append(deleteDirs, config.DataPath)
+	}
+	for _, deleteDir := range deleteDirs {
+		err = revertibleOps.Delete(deleteDir)
+		if err != nil {
+			err = burrito.WrapErrorf(err, updateSourceFilesError, deleteDir)
+			return err // Overwritten by defer
+		}
+	}
+	// Move files from tmp to each pack source and data.
 	absWorkingDir, err := GetAbsoluteWorkingDirectory(dotRegolithPath)
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
-	moveFiles := [][2]string{
-		{filepath.Join(absWorkingDir, "RP"), config.Packs.PrimaryResourceSource()},
-		{filepath.Join(absWorkingDir, "BP"), config.Packs.PrimaryBehaviorSource()},
-		{filepath.Join(absWorkingDir, "data"), config.DataPath},
+	moveFiles := [][2]string{}
+	for _, pack := range config.Packs.BehaviorPacks {
+		if pack.Source != "" {
+			moveFiles = append(moveFiles,
+				[2]string{filepath.Join(absWorkingDir, pack.Name), pack.Source})
+		}
+	}
+	for _, pack := range config.Packs.ResourcePacks {
+		if pack.Source != "" {
+			moveFiles = append(moveFiles,
+				[2]string{filepath.Join(absWorkingDir, pack.Name), pack.Source})
+		}
+	}
+	if config.DataPath != "" {
+		moveFiles = append(moveFiles,
+			[2]string{filepath.Join(absWorkingDir, "data"), config.DataPath})
 	}
 	for _, moveFile := range moveFiles {
 		source, target := moveFile[0], moveFile[1]
-		if source != "" {
-			err = revertibleOps.MoveOrCopyDir(source, target)
-			if err != nil {
-				err = burrito.WrapErrorf(
-					err, moveOrCopyError, source, target)
-				return err // Overwritten by defer
-			}
+		err = revertibleOps.MoveOrCopyDir(source, target)
+		if err != nil {
+			err = burrito.WrapErrorf(err, moveOrCopyError, source, target)
+			return err // Overwritten by defer
 		}
 	}
 	return err // Can be altered by defer

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -617,7 +617,7 @@ func InplaceExportProject(
 	}()
 	// Delete RP, BP and data before replacing them with files from tmp
 	deleteDirs := []string{
-		config.ResourceFolder, config.BehaviorFolder, config.DataPath}
+		config.PrimaryResourceSource(), config.PrimaryBehaviorSource(), config.DataPath}
 	for _, deleteDir := range deleteDirs {
 		if deleteDir != "" {
 			err = revertibleOps.Delete(deleteDir)
@@ -634,8 +634,8 @@ func InplaceExportProject(
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
 	}
 	moveFiles := [][2]string{
-		{filepath.Join(absWorkingDir, "RP"), config.ResourceFolder},
-		{filepath.Join(absWorkingDir, "BP"), config.BehaviorFolder},
+		{filepath.Join(absWorkingDir, "RP"), config.PrimaryResourceSource()},
+		{filepath.Join(absWorkingDir, "BP"), config.PrimaryBehaviorSource()},
 		{filepath.Join(absWorkingDir, "data"), config.DataPath},
 	}
 	for _, moveFile := range moveFiles {

--- a/regolith/export.go
+++ b/regolith/export.go
@@ -29,7 +29,7 @@ func GetExportPaths(
 	if semver.Compare(vFormatVersion, "v1.4.0") < 0 {
 		bpPath, rpPath, err = getExportPathsV1_2_0(
 			exportTarget, bpName, rpName)
-	} else if semver.Compare(vFormatVersion, "v1.8.0") <= 0 {
+	} else if semver.Compare(vFormatVersion, "v"+latestCompatibleVersion) <= 0 {
 		bpPath, rpPath, err = getExportPathsV1_4_0(
 			exportTarget, bpName, rpName)
 	} else {

--- a/regolith/file_protection.go
+++ b/regolith/file_protection.go
@@ -97,6 +97,38 @@ func (f *EditedFiles) UpdateFromPaths(rpPath string, bpPath string) error {
 	return nil
 }
 
+// CheckPackDeletionSafety runs the deletion-safety check for a single pack
+// directory. packType is "bp" or "rp".
+func (f *EditedFiles) CheckPackDeletionSafety(packType, path string) error {
+	files := f.packFiles(packType)[path]
+	if files == nil {
+		files = make([]string, 0)
+	}
+	if err := checkDeletionSafety(path, files); err != nil {
+		return burrito.WrapErrorf(
+			err, "Deletion safety check for %s pack failed.", packType)
+	}
+	return nil
+}
+
+// UpdatePackFromPath records the current file list of a single pack directory.
+// packType is "bp" or "rp".
+func (f *EditedFiles) UpdatePackFromPath(packType, path string) error {
+	files, err := listFiles(path)
+	if err != nil {
+		return burrito.WrapErrorf(err, "Failed to list %s pack files.", packType)
+	}
+	f.packFiles(packType)[path] = files
+	return nil
+}
+
+func (f *EditedFiles) packFiles(packType string) map[string]filesList {
+	if packType == "rp" {
+		return f.Rp
+	}
+	return f.Bp
+}
+
 // NewEditedFiles creates new EditedFiles object with lists of the files from
 // rpPath and bpPath.
 func NewEditedFiles() EditedFiles {

--- a/regolith/main_functions.go
+++ b/regolith/main_functions.go
@@ -478,8 +478,8 @@ func Init(debug, force bool, env string) error {
 		Name:   "Project name",
 		Author: *userConfig.Username,
 		Packs: Packs{
-			BehaviorFolder: "./packs/BP",
-			ResourceFolder: "./packs/RP",
+			BehaviorPacks: []Pack{{Name: "BP", Source: "./packs/BP"}},
+			ResourcePacks: []Pack{{Name: "RP", Source: "./packs/RP"}},
 		},
 		RegolithProject: RegolithProject{
 			FormatVersion:     "1.8.0",

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -226,8 +226,8 @@ func SetupTmpFiles(context RunContext) error {
 
 	// Copy the contents of the 'regolith' folder to '[dotRegolithPath]/tmp'
 	Logger.Debugf("Copying project files to \"%s\"", absTmpPath)
-	// Avoid repetitive code of preparing ResourceFolder, BehaviorFolder
-	// and DataPath with a closure
+	// Avoid repetitive code of preparing each pack folder and the data
+	// folder with a closure
 	setupTmpDirectory := func(
 		path, shortName, descriptiveName string,
 	) error {

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -269,13 +269,13 @@ func SetupTmpFiles(context RunContext) error {
 	errCh := make(chan error, 3)
 
 	wg.Go(func() {
-		if err := setupTmpDirectory(config.PrimaryResourceSource(), "RP", "resource folder"); err != nil {
+		if err := setupTmpDirectory(config.Packs.PrimaryResourceSource(), "RP", "resource folder"); err != nil {
 			errCh <- burrito.WrapErrorf(err, "Failed to setup RP folder in the temporary directory.")
 		}
 	})
 
 	wg.Go(func() {
-		if err := setupTmpDirectory(config.PrimaryBehaviorSource(), "BP", "behavior folder"); err != nil {
+		if err := setupTmpDirectory(config.Packs.PrimaryBehaviorSource(), "BP", "behavior folder"); err != nil {
 			errCh <- burrito.WrapErrorf(err, "Failed to setup BP folder in the temporary directory.")
 		}
 	})

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -121,6 +121,12 @@ func SetupTmpFiles(context RunContext) error {
 	start := time.Now()
 	useSizeTimeCheck := !context.DisableSizeTimeCheck
 	useSymlinkExport := context.SymlinkExport
+	// Symlink export only works with a single behavior and resource pack.
+	if useSymlinkExport &&
+		(len(config.Packs.BehaviorPacks) != 1 || len(config.Packs.ResourcePacks) != 1) {
+		Logger.Debugf("Symlink export is disabled because the project has multiple packs.")
+		useSymlinkExport = false
+	}
 	absTmpPath, err := GetAbsoluteWorkingDirectory(dotRegolithPath)
 	if err != nil {
 		return burrito.WrapError(err, getAbsoluteWorkingDirectoryError)
@@ -264,28 +270,35 @@ func SetupTmpFiles(context RunContext) error {
 		return nil
 	}
 
-	// Setup RP, BP and data folders concurrently
+	// Setup every behavior pack, every resource pack, and the data folder
+	// concurrently.
+	type tmpFolder struct {
+		source      string
+		name        string
+		descriptive string
+	}
+	var folders []tmpFolder
+	for _, pack := range config.Packs.BehaviorPacks {
+		folders = append(folders, tmpFolder{pack.Source, pack.Name, "behavior folder"})
+	}
+	for _, pack := range config.Packs.ResourcePacks {
+		folders = append(folders, tmpFolder{pack.Source, pack.Name, "resource folder"})
+	}
+	folders = append(folders, tmpFolder{config.DataPath, "data", "data folder"})
+
 	wg := sync.WaitGroup{}
-	errCh := make(chan error, 3)
-
-	wg.Go(func() {
-		if err := setupTmpDirectory(config.Packs.PrimaryResourceSource(), "RP", "resource folder"); err != nil {
-			errCh <- burrito.WrapErrorf(err, "Failed to setup RP folder in the temporary directory.")
-		}
-	})
-
-	wg.Go(func() {
-		if err := setupTmpDirectory(config.Packs.PrimaryBehaviorSource(), "BP", "behavior folder"); err != nil {
-			errCh <- burrito.WrapErrorf(err, "Failed to setup BP folder in the temporary directory.")
-		}
-	})
-
-	wg.Go(func() {
-		if err := setupTmpDirectory(config.DataPath, "data", "data folder"); err != nil {
-			errCh <- burrito.WrapErrorf(err, "Failed to setup data folder in the temporary directory.")
-		}
-	})
-
+	errCh := make(chan error, len(folders))
+	for _, folder := range folders {
+		folder := folder
+		wg.Go(func() {
+			if err := setupTmpDirectory(folder.source, folder.name, folder.descriptive); err != nil {
+				errCh <- burrito.WrapErrorf(
+					err,
+					"Failed to setup %s folder in the temporary directory.",
+					folder.name)
+			}
+		})
+	}
 	wg.Wait()
 	close(errCh)
 	for e := range errCh {

--- a/regolith/profile.go
+++ b/regolith/profile.go
@@ -269,13 +269,13 @@ func SetupTmpFiles(context RunContext) error {
 	errCh := make(chan error, 3)
 
 	wg.Go(func() {
-		if err := setupTmpDirectory(config.ResourceFolder, "RP", "resource folder"); err != nil {
+		if err := setupTmpDirectory(config.PrimaryResourceSource(), "RP", "resource folder"); err != nil {
 			errCh <- burrito.WrapErrorf(err, "Failed to setup RP folder in the temporary directory.")
 		}
 	})
 
 	wg.Go(func() {
-		if err := setupTmpDirectory(config.BehaviorFolder, "BP", "behavior folder"); err != nil {
+		if err := setupTmpDirectory(config.PrimaryBehaviorSource(), "BP", "behavior folder"); err != nil {
 			errCh <- burrito.WrapErrorf(err, "Failed to setup BP folder in the temporary directory.")
 		}
 	})

--- a/regolith/watcher.go
+++ b/regolith/watcher.go
@@ -44,25 +44,37 @@ type DirWatcher struct {
 	stage <-chan string
 }
 
+// watchRoots returns the directories the watcher should observe: every pack
+// source, the data folder, and any extra watch paths.
+func watchRoots(config *Config) []string {
+	var roots []string
+	for _, pack := range config.Packs.ResourcePacks {
+		if pack.Source != "" {
+			roots = append(roots, pack.Source)
+		}
+	}
+	for _, pack := range config.Packs.BehaviorPacks {
+		if pack.Source != "" {
+			roots = append(roots, pack.Source)
+		}
+	}
+	if config.DataPath != "" {
+		roots = append(roots, config.DataPath)
+	}
+	roots = append(roots, config.WatchPaths...)
+	return roots
+}
+
+// WatchRootsForTest exposes watchRoots for external tests.
+func WatchRootsForTest(config *Config) []string { return watchRoots(config) }
+
 func NewDirWatcher(
 	config *Config,
 	interruption chan string,
 	errors chan error,
 	stage <-chan string,
 ) error {
-	var roots []string
-	if config.Packs.PrimaryResourceSource() != "" {
-		roots = append(roots, config.Packs.PrimaryResourceSource())
-	}
-	if config.Packs.PrimaryBehaviorSource() != "" {
-		roots = append(roots, config.Packs.PrimaryBehaviorSource())
-	}
-	if config.DataPath != "" {
-		roots = append(roots, config.DataPath)
-	}
-	if config.WatchPaths != nil {
-		roots = append(roots, config.WatchPaths...)
-	}
+	roots := watchRoots(config)
 	d := &DirWatcher{
 		roots:        roots,
 		config:       config,
@@ -122,13 +134,28 @@ func (d *DirWatcher) start() {
 			if d.debounce != nil || event.Op.Has(fsnotify.Chmod) {
 				continue
 			}
-			if isInDir(event.Name, d.config.Packs.PrimaryResourceSource()) {
-				d.interruption <- "rp"
-			} else if isInDir(event.Name, d.config.Packs.PrimaryBehaviorSource()) {
-				d.interruption <- "bp"
-			} else if isInDir(event.Name, d.config.DataPath) {
+			matched := false
+			for _, pack := range d.config.Packs.BehaviorPacks {
+				if pack.Source != "" && isInDir(event.Name, pack.Source) {
+					d.interruption <- "bp"
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				for _, pack := range d.config.Packs.ResourcePacks {
+					if pack.Source != "" && isInDir(event.Name, pack.Source) {
+						d.interruption <- "rp"
+						matched = true
+						break
+					}
+				}
+			}
+			if !matched && isInDir(event.Name, d.config.DataPath) {
 				d.interruption <- "data"
-			} else {
+				matched = true
+			}
+			if !matched {
 				for _, path := range d.config.WatchPaths {
 					if isInDir(event.Name, path) {
 						d.interruption <- "extras"

--- a/regolith/watcher.go
+++ b/regolith/watcher.go
@@ -51,11 +51,11 @@ func NewDirWatcher(
 	stage <-chan string,
 ) error {
 	var roots []string
-	if config.PrimaryResourceSource() != "" {
-		roots = append(roots, config.PrimaryResourceSource())
+	if config.Packs.PrimaryResourceSource() != "" {
+		roots = append(roots, config.Packs.PrimaryResourceSource())
 	}
-	if config.PrimaryBehaviorSource() != "" {
-		roots = append(roots, config.PrimaryBehaviorSource())
+	if config.Packs.PrimaryBehaviorSource() != "" {
+		roots = append(roots, config.Packs.PrimaryBehaviorSource())
 	}
 	if config.DataPath != "" {
 		roots = append(roots, config.DataPath)
@@ -122,9 +122,9 @@ func (d *DirWatcher) start() {
 			if d.debounce != nil || event.Op.Has(fsnotify.Chmod) {
 				continue
 			}
-			if isInDir(event.Name, d.config.PrimaryResourceSource()) {
+			if isInDir(event.Name, d.config.Packs.PrimaryResourceSource()) {
 				d.interruption <- "rp"
-			} else if isInDir(event.Name, d.config.PrimaryBehaviorSource()) {
+			} else if isInDir(event.Name, d.config.Packs.PrimaryBehaviorSource()) {
 				d.interruption <- "bp"
 			} else if isInDir(event.Name, d.config.DataPath) {
 				d.interruption <- "data"

--- a/regolith/watcher.go
+++ b/regolith/watcher.go
@@ -51,11 +51,11 @@ func NewDirWatcher(
 	stage <-chan string,
 ) error {
 	var roots []string
-	if config.ResourceFolder != "" {
-		roots = append(roots, config.ResourceFolder)
+	if config.PrimaryResourceSource() != "" {
+		roots = append(roots, config.PrimaryResourceSource())
 	}
-	if config.BehaviorFolder != "" {
-		roots = append(roots, config.BehaviorFolder)
+	if config.PrimaryBehaviorSource() != "" {
+		roots = append(roots, config.PrimaryBehaviorSource())
 	}
 	if config.DataPath != "" {
 		roots = append(roots, config.DataPath)
@@ -122,9 +122,9 @@ func (d *DirWatcher) start() {
 			if d.debounce != nil || event.Op.Has(fsnotify.Chmod) {
 				continue
 			}
-			if isInDir(event.Name, d.config.ResourceFolder) {
+			if isInDir(event.Name, d.config.PrimaryResourceSource()) {
 				d.interruption <- "rp"
-			} else if isInDir(event.Name, d.config.BehaviorFolder) {
+			} else if isInDir(event.Name, d.config.PrimaryBehaviorSource()) {
 				d.interruption <- "bp"
 			} else if isInDir(event.Name, d.config.DataPath) {
 				d.interruption <- "data"

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -204,6 +204,42 @@ func TestExportTargetParsesPerPackMaps(t *testing.T) {
 	}
 }
 
+func TestGetExportNameDefaultsAndOverrides(t *testing.T) {
+	regolith.InitLogging(true)
+	ctx := regolith.RunContext{
+		Config: &regolith.Config{Name: "proj"},
+	}
+	cases := []struct {
+		pack     regolith.Pack
+		packType string
+		target   regolith.ExportTarget
+		want     string
+	}{
+		{regolith.Pack{Name: "BP"}, "bp", regolith.ExportTarget{}, "proj_bp"},
+		{regolith.Pack{Name: "BP1"}, "bp", regolith.ExportTarget{}, "proj_bp1"},
+		{regolith.Pack{Name: "RP2"}, "rp", regolith.ExportTarget{}, "proj_rp2"},
+		{
+			regolith.Pack{Name: "BP1"}, "bp",
+			regolith.ExportTarget{BpNames: map[string]string{"BP1": "'addon_bp'"}},
+			"addon_bp",
+		},
+		{
+			regolith.Pack{Name: "BP"}, "bp",
+			regolith.ExportTarget{BpName: "'primary_bp'"},
+			"primary_bp",
+		},
+	}
+	for _, c := range cases {
+		got, err := regolith.GetExportName(c.target, ctx, c.pack, c.packType)
+		if err != nil {
+			t.Fatalf("pack %s: %v", c.pack.Name, err)
+		}
+		if got != c.want {
+			t.Fatalf("pack %s: want %q got %q", c.pack.Name, c.want, got)
+		}
+	}
+}
+
 func TestSetupTmpFilesCreatesAllPackFolders(t *testing.T) {
 	defer os.Chdir(getWdOrFatal(t))
 	tmpDir := prepareTestDirectory(

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -2,7 +2,11 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Bedrock-OSS/regolith/regolith"
 )
@@ -171,5 +175,41 @@ func TestPacksMarshal_MultiProducesMaps(t *testing.T) {
 	if len(roundTrip.BehaviorPacks) != 2 ||
 		roundTrip.BehaviorPacks[1].Name != "BP1" {
 		t.Fatalf("round trip lost packs: %+v", roundTrip.BehaviorPacks)
+	}
+}
+
+func TestSetupTmpFilesCreatesAllPackFolders(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(minimalProjectPath, workingDir, t)
+
+	config := []byte(`{
+		"$schema": "x",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPacks": { "BP": "./packs/BP", "BP1": "./packs/BP" },
+			"resourcePacks": { "RP": "./packs/RP" }
+		},
+		"regolith": {
+			"formatVersion": "1.9.0",
+			"profiles": {
+				"dev": { "filters": [], "export": { "target": "local" } }
+			},
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal(err)
+	}
+	os.Chdir(workingDir)
+	if err := regolith.Run("dev", []string{}, true, "", false, false, false); err != nil {
+		t.Fatal("run failed:", err)
+	}
+	for _, packName := range []string{"BP", "BP1", "RP", "data"} {
+		assertDirExistsOrFatal(
+			filepath.Join(workingDir, ".regolith", "tmp", packName), t)
 	}
 }

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -178,6 +178,32 @@ func TestPacksMarshal_MultiProducesMaps(t *testing.T) {
 	}
 }
 
+func TestExportTargetParsesPerPackMaps(t *testing.T) {
+	obj := map[string]any{
+		"target": "exact",
+		"bpPath": "../out/BP",
+		"bpPaths": map[string]any{
+			"BP1": "../out/BP1",
+		},
+		"bpNames": map[string]any{
+			"BP1": "'addon_bp'",
+		},
+	}
+	target, err := regolith.ExportTargetFromObject(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.BpPaths["BP1"] != "../out/BP1" {
+		t.Fatalf("expected bpPaths[BP1], got %+v", target.BpPaths)
+	}
+	if target.BpNames["BP1"] != "'addon_bp'" {
+		t.Fatalf("expected bpNames[BP1], got %+v", target.BpNames)
+	}
+	if target.BpPath != "../out/BP" {
+		t.Fatalf("expected bpPath preserved, got %q", target.BpPath)
+	}
+}
+
 func TestSetupTmpFilesCreatesAllPackFolders(t *testing.T) {
 	defer os.Chdir(getWdOrFatal(t))
 	tmpDir := prepareTestDirectory(

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -324,6 +324,88 @@ func TestSetupTmpFilesCreatesAllPackFolders(t *testing.T) {
 	}
 }
 
+func TestMultiPackInplaceExportRestoresAllSources(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	regolith.InitLogging(true)
+	defer regolith.ShutdownLogging()
+
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	copyFilesOrFatal(minimalProjectPath, tmpDir, t)
+
+	// Add a second behavior pack source.
+	if err := os.MkdirAll(filepath.Join(tmpDir, "packs", "BP1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(tmpDir, "packs", "BP1", "old.txt"), []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	config := []byte(`{
+		"$schema": "x",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPacks": { "BP": "./packs/BP", "BP1": "./packs/BP1" },
+			"resourcePacks": { "RP": "./packs/RP" }
+		},
+		"regolith": {
+			"formatVersion": "1.9.0",
+			"profiles": { "dev": { "filters": [], "export": { "target": "local" } } },
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), config, 0644); err != nil {
+		t.Fatal(err)
+	}
+	os.Chdir(tmpDir)
+
+	// Populate the tmp pack folders as if filters had produced output.
+	tmpRoot := filepath.Join(tmpDir, ".regolith", "tmp")
+	for name, content := range map[string]string{
+		"BP": "bp-out", "BP1": "bp1-out", "RP": "rp-out", "data": "data-out",
+	} {
+		dir := filepath.Join(tmpRoot, name)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "out.txt"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	configMap, err := regolith.LoadConfigAsMap()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := regolith.ConfigFromObject(configMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := regolith.InplaceExportProject(parsed, ".regolith"); err != nil {
+		t.Fatal("InplaceExportProject failed:", err)
+	}
+
+	// Each pack source now holds the tmp output; the old BP1 file is gone.
+	assertFileContentForTest(t, filepath.Join(tmpDir, "packs", "BP", "out.txt"), "bp-out")
+	assertFileContentForTest(t, filepath.Join(tmpDir, "packs", "BP1", "out.txt"), "bp1-out")
+	assertFileContentForTest(t, filepath.Join(tmpDir, "packs", "RP", "out.txt"), "rp-out")
+	if _, err := os.Stat(filepath.Join(tmpDir, "packs", "BP1", "old.txt")); !os.IsNotExist(err) {
+		t.Fatal("expected old BP1 file to be replaced")
+	}
+}
+
+func assertFileContentForTest(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %q: %v", path, err)
+	}
+	if string(data) != want {
+		t.Fatalf("%q: want %q got %q", path, want, string(data))
+	}
+}
+
 func TestMultiPackLocalExport(t *testing.T) {
 	defer os.Chdir(getWdOrFatal(t))
 	tmpDir := prepareTestDirectory(

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -1,10 +1,20 @@
 package test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/Bedrock-OSS/regolith/regolith"
 )
+
+func mustUnmarshalObject(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatal(err)
+	}
+	return obj
+}
 
 func TestPackSortingAndPrimaryAccessors(t *testing.T) {
 	packs := regolith.Packs{
@@ -34,5 +44,132 @@ func TestPackSortingAndPrimaryAccessors(t *testing.T) {
 	}
 	if !(regolith.Packs{}).IsZero() {
 		t.Fatal("empty packs should report IsZero")
+	}
+}
+
+func TestPacksFromObject_SingleStringSugar(t *testing.T) {
+	obj := map[string]any{
+		"behaviorPack": "./packs/BP",
+		"resourcePack": "./packs/RP",
+	}
+	packs, err := regolith.PacksFromObject(obj, "1.9.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packs.BehaviorPacks) != 1 || packs.BehaviorPacks[0].Name != "BP" ||
+		packs.BehaviorPacks[0].Source != "./packs/BP" {
+		t.Fatalf("unexpected behavior packs: %+v", packs.BehaviorPacks)
+	}
+	if len(packs.ResourcePacks) != 1 || packs.ResourcePacks[0].Name != "RP" {
+		t.Fatalf("unexpected resource packs: %+v", packs.ResourcePacks)
+	}
+}
+
+func TestPacksFromObject_MapForm(t *testing.T) {
+	obj := map[string]any{
+		"behaviorPacks": map[string]any{
+			"BP":  "./packs/BP",
+			"BP1": "./packs/addon",
+		},
+		"resourcePacks": map[string]any{
+			"RP": "./packs/RP",
+		},
+	}
+	packs, err := regolith.PacksFromObject(obj, "1.9.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packs.BehaviorPacks) != 2 ||
+		packs.BehaviorPacks[0].Name != "BP" ||
+		packs.BehaviorPacks[1].Name != "BP1" ||
+		packs.BehaviorPacks[1].Source != "./packs/addon" {
+		t.Fatalf("unexpected behavior packs: %+v", packs.BehaviorPacks)
+	}
+}
+
+func TestPacksFromObject_MapRejectedOnOldVersion(t *testing.T) {
+	obj := map[string]any{
+		"behaviorPacks": map[string]any{"BP": "./packs/BP"},
+	}
+	if _, err := regolith.PacksFromObject(obj, "1.8.0"); err == nil {
+		t.Fatal("expected error for map form on formatVersion 1.8.0")
+	}
+}
+
+func TestPacksFromObject_InvalidKey(t *testing.T) {
+	for _, badKey := range []string{"BP0", "RP0", "pack", "BP01"} {
+		obj := map[string]any{
+			"behaviorPacks": map[string]any{badKey: "./x"},
+		}
+		if _, err := regolith.PacksFromObject(obj, "1.9.0"); err == nil {
+			t.Fatalf("expected error for invalid key %q", badKey)
+		}
+	}
+}
+
+func TestPacksFromObject_MapWithoutPrimaryGetsEmptyPrimary(t *testing.T) {
+	obj := map[string]any{
+		"behaviorPacks": map[string]any{"BP1": "./packs/addon"},
+	}
+	packs, err := regolith.PacksFromObject(obj, "1.9.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packs.BehaviorPacks) != 2 || packs.BehaviorPacks[0].Name != "BP" ||
+		packs.BehaviorPacks[0].Source != "" {
+		t.Fatalf("expected synthesized empty primary BP first: %+v", packs.BehaviorPacks)
+	}
+}
+
+func TestPacksFromObject_MixedFormRejected(t *testing.T) {
+	obj := map[string]any{
+		"behaviorPack":  "./packs/BP",
+		"behaviorPacks": map[string]any{"BP1": "./x"},
+	}
+	if _, err := regolith.PacksFromObject(obj, "1.9.0"); err == nil {
+		t.Fatal("expected error when mixing behaviorPack and behaviorPacks")
+	}
+}
+
+func TestPacksMarshal_SingleDefaultProducesStrings(t *testing.T) {
+	packs := regolith.Packs{
+		BehaviorPacks: []regolith.Pack{{Name: "BP", Source: "./packs/BP"}},
+		ResourcePacks: []regolith.Pack{{Name: "RP", Source: "./packs/RP"}},
+	}
+	data, err := json.Marshal(packs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if obj["behaviorPack"] != "./packs/BP" {
+		t.Fatalf("expected behaviorPack string, got: %s", data)
+	}
+	if _, isMap := obj["behaviorPacks"]; isMap {
+		t.Fatalf("single pack should not marshal as map: %s", data)
+	}
+}
+
+func TestPacksMarshal_MultiProducesMaps(t *testing.T) {
+	packs := regolith.Packs{
+		BehaviorPacks: []regolith.Pack{
+			{Name: "BP", Source: "./packs/BP"},
+			{Name: "BP1", Source: "./packs/addon"},
+		},
+		ResourcePacks: []regolith.Pack{{Name: "RP", Source: "./packs/RP"}},
+	}
+	data, err := json.Marshal(packs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundTrip, err := regolith.PacksFromObject(mustUnmarshalObject(t, data), "1.9.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roundTrip.BehaviorPacks) != 2 ||
+		roundTrip.BehaviorPacks[1].Name != "BP1" {
+		t.Fatalf("round trip lost packs: %+v", roundTrip.BehaviorPacks)
 	}
 }

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -323,3 +323,45 @@ func TestSetupTmpFilesCreatesAllPackFolders(t *testing.T) {
 			filepath.Join(workingDir, ".regolith", "tmp", packName), t)
 	}
 }
+
+func TestMultiPackLocalExport(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(minimalProjectPath, workingDir, t)
+
+	config := []byte(`{
+		"$schema": "x",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPacks": { "BP": "./packs/BP", "BP1": "./packs/BP" },
+			"resourcePacks": { "RP": "./packs/RP" }
+		},
+		"regolith": {
+			"formatVersion": "1.9.0",
+			"profiles": {
+				"dev": { "filters": [], "export": { "target": "local" } }
+			},
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal(err)
+	}
+	os.Chdir(workingDir)
+	if err := regolith.Run("dev", []string{}, true, "", false, false, false); err != nil {
+		t.Fatal("run failed:", err)
+	}
+	srcBp := filepath.Join(workingDir, "packs", "BP")
+	comparePaths(srcBp, filepath.Join(workingDir, "build", "regolith_test_project_bp"), t)
+	comparePaths(srcBp, filepath.Join(workingDir, "build", "regolith_test_project_bp1"), t)
+	comparePaths(
+		filepath.Join(workingDir, "packs", "RP"),
+		filepath.Join(workingDir, "build", "regolith_test_project_rp"), t)
+	// running again must pass file-protection safety checks
+	if err := regolith.Run("dev", []string{}, true, "", false, false, false); err != nil {
+		t.Fatal("second run failed:", err)
+	}
+}

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -494,3 +494,81 @@ func TestMultiPackProjectLocalBuild(t *testing.T) {
 		filepath.Join(tmpDir, "packs", "RP"),
 		filepath.Join(tmpDir, "build", "multi_pack_project_rp"), t)
 }
+
+func TestMultiPackExactExport(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(multiPackProjectPath, workingDir, t)
+
+	config := []byte(`{
+		"$schema": "x",
+		"name": "multi_pack_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPacks": { "BP": "./packs/BP", "BP1": "./packs/BP1" },
+			"resourcePacks": { "RP": "./packs/RP" }
+		},
+		"regolith": {
+			"formatVersion": "1.9.0",
+			"dataPath": "./packs/data",
+			"profiles": {
+				"exact": {
+					"filters": [],
+					"export": {
+						"target": "exact",
+						"bpPath": "../out/BP",
+						"rpPath": "../out/RP",
+						"bpPaths": { "BP1": "../out/BP1" }
+					}
+				}
+			}
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal(err)
+	}
+	os.Chdir(workingDir)
+	if err := regolith.Run("exact", []string{}, true, "", false, false, false); err != nil {
+		t.Fatal("exact run failed:", err)
+	}
+	comparePaths(filepath.Join(workingDir, "packs", "BP"), filepath.Join(tmpDir, "out", "BP"), t)
+	comparePaths(filepath.Join(workingDir, "packs", "BP1"), filepath.Join(tmpDir, "out", "BP1"), t)
+	comparePaths(filepath.Join(workingDir, "packs", "RP"), filepath.Join(tmpDir, "out", "RP"), t)
+}
+
+func TestMultiPackExactExportMissingPathFails(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(multiPackProjectPath, workingDir, t)
+
+	config := []byte(`{
+		"$schema": "x",
+		"name": "multi_pack_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPacks": { "BP": "./packs/BP", "BP1": "./packs/BP1" },
+			"resourcePacks": { "RP": "./packs/RP" }
+		},
+		"regolith": {
+			"formatVersion": "1.9.0",
+			"dataPath": "./packs/data",
+			"profiles": {
+				"exact": {
+					"filters": [],
+					"export": { "target": "exact", "bpPath": "../out/BP", "rpPath": "../out/RP" }
+				}
+			}
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal(err)
+	}
+	os.Chdir(workingDir)
+	if err := regolith.Run("exact", []string{}, true, "", false, false, false); err == nil {
+		t.Fatal("expected error: BP1 has no exact path")
+	}
+}

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -237,6 +238,53 @@ func TestGetExportNameDefaultsAndOverrides(t *testing.T) {
 		if got != c.want {
 			t.Fatalf("pack %s: want %q got %q", c.pack.Name, c.want, got)
 		}
+	}
+}
+
+func TestGetPackExportPathLocalAndExact(t *testing.T) {
+	regolith.InitLogging(true)
+	ctx := regolith.RunContext{
+		Config: &regolith.Config{
+			Name: "proj",
+			RegolithProject: regolith.RegolithProject{FormatVersion: "1.9.0"},
+		},
+	}
+	// local target -> build/<name>/
+	localBp, err := regolith.GetPackExportPath(
+		regolith.ExportTarget{Target: "local"}, ctx,
+		regolith.Pack{Name: "BP1"}, "bp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localBp != "build/proj_bp1/" {
+		t.Fatalf("local: got %q", localBp)
+	}
+	// exact target with a per-pack map
+	exact := regolith.ExportTarget{
+		Target:  "exact",
+		BpPath:  "out/BP",
+		BpPaths: map[string]string{"BP1": "out/BP1"},
+	}
+	primary, err := regolith.GetPackExportPath(exact, ctx, regolith.Pack{Name: "BP"}, "bp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(primary), "out/BP") {
+		t.Fatalf("exact primary: got %q", primary)
+	}
+	addon, err := regolith.GetPackExportPath(exact, ctx, regolith.Pack{Name: "BP1"}, "bp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(addon), "out/BP1") {
+		t.Fatalf("exact addon: got %q", addon)
+	}
+	// exact target missing a path for an extra pack -> error
+	_, err = regolith.GetPackExportPath(
+		regolith.ExportTarget{Target: "exact", BpPath: "out/BP"}, ctx,
+		regolith.Pack{Name: "BP1"}, "bp")
+	if err == nil {
+		t.Fatal("expected error for extra pack without exact path")
 	}
 }
 

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -21,7 +21,7 @@ func mustUnmarshalObject(t *testing.T, data []byte) map[string]any {
 	return obj
 }
 
-func TestPackSortingAndPrimaryAccessors(t *testing.T) {
+func TestPackSortingAndIsZero(t *testing.T) {
 	packs := regolith.Packs{
 		BehaviorPacks: []regolith.Pack{
 			{Name: "BP2", Source: "b2"},
@@ -37,12 +37,6 @@ func TestPackSortingAndPrimaryAccessors(t *testing.T) {
 		packs.BehaviorPacks[1].Name != "BP1" ||
 		packs.BehaviorPacks[2].Name != "BP2" {
 		t.Fatalf("packs not sorted by index: %+v", packs.BehaviorPacks)
-	}
-	if packs.PrimaryBehaviorSource() != "b0" {
-		t.Fatalf("expected primary bp source b0, got %q", packs.PrimaryBehaviorSource())
-	}
-	if packs.PrimaryResourceSource() != "r0" {
-		t.Fatalf("expected primary rp source r0, got %q", packs.PrimaryResourceSource())
 	}
 	if packs.IsZero() {
 		t.Fatal("non-empty packs reported IsZero")
@@ -623,5 +617,54 @@ func TestMultiPackExactExportMissingPathFails(t *testing.T) {
 	os.Chdir(workingDir)
 	if err := regolith.Run("exact", []string{}, true, "", false, false, false); err == nil {
 		t.Fatal("expected error: BP1 has no exact path")
+	}
+}
+
+func TestMultiPackWorldExport(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(minimalProjectPath, workingDir, t)
+
+	// worldPath is relative to workingDir; resolves to tmpDir/myworld.
+	worldDir := filepath.Join(tmpDir, "myworld")
+
+	config := []byte(`{
+		"$schema": "x",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPacks": { "BP": "./packs/BP", "BP1": "./packs/BP" },
+			"resourcePacks": { "RP": "./packs/RP" }
+		},
+		"regolith": {
+			"formatVersion": "1.9.0",
+			"profiles": {
+				"world": {
+					"filters": [],
+					"export": { "target": "world", "worldPath": "../myworld" }
+				}
+			},
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal(err)
+	}
+	os.Chdir(workingDir)
+	if err := regolith.Run("world", []string{}, true, "", false, false, false); err != nil {
+		t.Fatal("first world run failed:", err)
+	}
+
+	srcBp := filepath.Join(workingDir, "packs", "BP")
+	srcRp := filepath.Join(workingDir, "packs", "RP")
+	comparePaths(srcBp, filepath.Join(worldDir, "behavior_packs", "regolith_test_project_bp"), t)
+	comparePaths(srcBp, filepath.Join(worldDir, "behavior_packs", "regolith_test_project_bp1"), t)
+	comparePaths(srcRp, filepath.Join(worldDir, "resource_packs", "regolith_test_project_rp"), t)
+
+	// Second run must pass file-protection safety checks.
+	if err := regolith.Run("world", []string{}, true, "", false, false, false); err != nil {
+		t.Fatal("second world run failed:", err)
 	}
 }

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -472,3 +472,25 @@ func TestMultiPackLocalExport(t *testing.T) {
 		t.Fatal("second run failed:", err)
 	}
 }
+
+const multiPackProjectPath = "testdata/multi_pack/project"
+
+func TestMultiPackProjectLocalBuild(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	copyFilesOrFatal(multiPackProjectPath, tmpDir, t)
+	os.Chdir(tmpDir)
+	if err := regolith.Run("dev", []string{}, true, "", false, false, false); err != nil {
+		t.Fatal("run failed:", err)
+	}
+	comparePaths(
+		filepath.Join(tmpDir, "packs", "BP"),
+		filepath.Join(tmpDir, "build", "multi_pack_project_bp"), t)
+	comparePaths(
+		filepath.Join(tmpDir, "packs", "BP1"),
+		filepath.Join(tmpDir, "build", "multi_pack_project_bp1"), t)
+	comparePaths(
+		filepath.Join(tmpDir, "packs", "RP"),
+		filepath.Join(tmpDir, "build", "multi_pack_project_rp"), t)
+}

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -245,7 +245,7 @@ func TestGetPackExportPathLocalAndExact(t *testing.T) {
 	regolith.InitLogging(true)
 	ctx := regolith.RunContext{
 		Config: &regolith.Config{
-			Name: "proj",
+			Name:            "proj",
 			RegolithProject: regolith.RegolithProject{FormatVersion: "1.9.0"},
 		},
 	}
@@ -536,6 +536,59 @@ func TestMultiPackExactExport(t *testing.T) {
 	comparePaths(filepath.Join(workingDir, "packs", "BP"), filepath.Join(tmpDir, "out", "BP"), t)
 	comparePaths(filepath.Join(workingDir, "packs", "BP1"), filepath.Join(tmpDir, "out", "BP1"), t)
 	comparePaths(filepath.Join(workingDir, "packs", "RP"), filepath.Join(tmpDir, "out", "RP"), t)
+}
+
+func TestMultiPackDevelopmentExport(t *testing.T) {
+	defer os.Chdir(getWdOrFatal(t))
+
+	tmpDir := prepareTestDirectory(
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()), t)
+	workingDir := filepath.Join(tmpDir, "working-dir")
+	copyFilesOrFatal(minimalProjectPath, workingDir, t)
+
+	mojangDir := filepath.Join(tmpDir, "com.mojang")
+	if err := os.MkdirAll(mojangDir, 0755); err != nil {
+		t.Fatal("Unable to create fake com.mojang directory:", err)
+	}
+	t.Setenv("COM_MOJANG_PACKS", mojangDir)
+
+	config := []byte(`{
+		"$schema": "x",
+		"name": "regolith_test_project",
+		"author": "Bedrock-OSS",
+		"packs": {
+			"behaviorPacks": { "BP": "./packs/BP", "BP1": "./packs/BP" },
+			"resourcePacks": { "RP": "./packs/RP" }
+		},
+		"regolith": {
+			"formatVersion": "1.9.0",
+			"profiles": {
+				"dev": {
+					"filters": [],
+					"export": { "target": "development", "build": "standard" }
+				}
+			},
+			"dataPath": "./packs/data"
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(workingDir, "config.json"), config, 0644); err != nil {
+		t.Fatal("Unable to write multi-pack development config:", err)
+	}
+
+	os.Chdir(workingDir)
+	if err := regolith.Run("dev", []string{}, false, "", false, false, false); err != nil {
+		t.Fatal("First multi-pack development run failed:", err)
+	}
+
+	srcBp := filepath.Join(workingDir, "packs", "BP")
+	srcRp := filepath.Join(workingDir, "packs", "RP")
+	comparePaths(srcBp, filepath.Join(mojangDir, "development_behavior_packs", "regolith_test_project_bp"), t)
+	comparePaths(srcBp, filepath.Join(mojangDir, "development_behavior_packs", "regolith_test_project_bp1"), t)
+	comparePaths(srcRp, filepath.Join(mojangDir, "development_resource_packs", "regolith_test_project_rp"), t)
+
+	if err := regolith.Run("dev", []string{}, false, "", false, false, false); err != nil {
+		t.Fatal("Second multi-pack development run failed safety checks:", err)
+	}
 }
 
 func TestMultiPackExactExportMissingPathFails(t *testing.T) {

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/Bedrock-OSS/regolith/regolith"
+)
+
+func TestPackSortingAndPrimaryAccessors(t *testing.T) {
+	packs := regolith.Packs{
+		BehaviorPacks: []regolith.Pack{
+			{Name: "BP2", Source: "b2"},
+			{Name: "BP", Source: "b0"},
+			{Name: "BP1", Source: "b1"},
+		},
+		ResourcePacks: []regolith.Pack{
+			{Name: "RP", Source: "r0"},
+		},
+	}
+	regolith.SortPacksForTest(packs.BehaviorPacks)
+	if packs.BehaviorPacks[0].Name != "BP" ||
+		packs.BehaviorPacks[1].Name != "BP1" ||
+		packs.BehaviorPacks[2].Name != "BP2" {
+		t.Fatalf("packs not sorted by index: %+v", packs.BehaviorPacks)
+	}
+	if packs.PrimaryBehaviorSource() != "b0" {
+		t.Fatalf("expected primary bp source b0, got %q", packs.PrimaryBehaviorSource())
+	}
+	if packs.PrimaryResourceSource() != "r0" {
+		t.Fatalf("expected primary rp source r0, got %q", packs.PrimaryResourceSource())
+	}
+	if packs.IsZero() {
+		t.Fatal("non-empty packs reported IsZero")
+	}
+	if !(regolith.Packs{}).IsZero() {
+		t.Fatal("empty packs should report IsZero")
+	}
+}

--- a/test/multi_pack_test.go
+++ b/test/multi_pack_test.go
@@ -406,6 +406,31 @@ func assertFileContentForTest(t *testing.T, path, want string) {
 	}
 }
 
+func TestWatchRootsIncludeAllPackSources(t *testing.T) {
+	config := &regolith.Config{
+		Packs: regolith.Packs{
+			BehaviorPacks: []regolith.Pack{
+				{Name: "BP", Source: "./packs/BP"},
+				{Name: "BP1", Source: "./packs/addon"},
+			},
+			ResourcePacks: []regolith.Pack{{Name: "RP", Source: "./packs/RP"}},
+		},
+		RegolithProject: regolith.RegolithProject{DataPath: "./packs/data"},
+	}
+	roots := regolith.WatchRootsForTest(config)
+	for _, want := range []string{"./packs/BP", "./packs/addon", "./packs/RP", "./packs/data"} {
+		found := false
+		for _, r := range roots {
+			if r == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("watch roots missing %q: %v", want, roots)
+		}
+	}
+}
+
 func TestMultiPackLocalExport(t *testing.T) {
 	defer os.Chdir(getWdOrFatal(t))
 	tmpDir := prepareTestDirectory(

--- a/test/testdata/multi_pack/project/config.json
+++ b/test/testdata/multi_pack/project/config.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://raw.githubusercontent.com/Bedrock-OSS/regolith-schemas/main/config/unified.json",
+	"name": "multi_pack_project",
+	"author": "Bedrock-OSS",
+	"packs": {
+		"behaviorPacks": {
+			"BP": "./packs/BP",
+			"BP1": "./packs/BP1"
+		},
+		"resourcePacks": {
+			"RP": "./packs/RP"
+		}
+	},
+	"regolith": {
+		"formatVersion": "1.9.0",
+		"dataPath": "./packs/data",
+		"filterDefinitions": {},
+		"profiles": {
+			"dev": {
+				"filters": [],
+				"export": { "target": "local" }
+			}
+		}
+	}
+}

--- a/test/testdata/multi_pack/project/packs/BP/manifest.json
+++ b/test/testdata/multi_pack/project/packs/BP/manifest.json
@@ -1,0 +1,1 @@
+{ "format_version": 2, "header": { "name": "primary_bp" } }

--- a/test/testdata/multi_pack/project/packs/BP1/manifest.json
+++ b/test/testdata/multi_pack/project/packs/BP1/manifest.json
@@ -1,0 +1,1 @@
+{ "format_version": 2, "header": { "name": "addon_bp" } }

--- a/test/testdata/multi_pack/project/packs/RP/manifest.json
+++ b/test/testdata/multi_pack/project/packs/RP/manifest.json
@@ -1,0 +1,1 @@
+{ "format_version": 2, "header": { "name": "primary_rp" } }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is just a prototype, not meant to be merged _yet_!
> It contains a lot of untested AI code, as also the description might not be the best (sorry!)
> The goal is to explore possible ways to bring multi pack support into regolith, if you have suggestions feel free to jump in!

Adds support for projects with more than one behavior and/or resource pack. Until now a Regolith project was hard-wired to exactly one BP and one RP; this PR generalizes the whole pipeline (config → tmp setup → filters → export → watcher → apply-filter) to an arbitrary number of packs per type.

Bumps `latestCompatibleVersion` to **1.9.0**. Everything below is gated on `formatVersion >= 1.9.0` — projects on older format versions behave exactly as before.

## Config format

The `packs` object accepts a new plural map form, keyed by pack name:

```json
"packs": {
    "behaviorPacks": { "BP": "./packs/BP", "BP1": "./packs/BP1" },
    "resourcePacks": { "RP": "./packs/RP" }
}
```

- Pack names must be `BP`/`RP` (the primary pack) or `BP1`, `BP2`, … (`BP0` is rejected). The primary pack always exists, even when it has no source on disk (a pack fully generated by filters is allowed).
- The old singular `behaviorPack`/`resourcePack` strings still work and are still what gets written back out for single-pack projects, so existing `config.json` files round-trip unchanged.
- Mixing the singular and plural form for the same pack type is an error, and so is using the plural form on `formatVersion < 1.9.0`.

Export targets get per-pack overrides, resolved as per-pack map → singular `bpName`/`rpName` (primary only) → default `<projectName>_bp<index>`:

```json
"export": {
    "target": "exact",
    "bpPaths": { "BP": "...", "BP1": "..." },
    "bpNames": { "BP1": "My Second Pack" }
}
```

`exact` targets now fail with a clear error when a pack has no configured path.

## Main changes

- **`config.go`** — new `Pack`/`Packs` data model with ordering helpers, version-gated parsing, and a custom `MarshalJSON` that keeps the legacy single-pack output. `ExportTarget` gains `bpNames`/`rpNames`/`bpPaths`/`rpPaths`.
- **`profile.go`** — `SetupTmpFiles` creates one tmp folder per pack (`tmp/BP`, `tmp/BP1`, `tmp/RP`, …) instead of the fixed BP/RP pair; all folders are still prepared concurrently.
- **`export.go`** — new `GetPackExportPath`/`GetExportName` resolve destination and name per pack for every target type (`development`, `world`, `exact`, `local`, `none`); `ExportProject` resolves *all* packs of *all* targets up front (keeping export atomic and collision-checked) and then exports each pack from its own tmp folder. `InplaceExportProject` (`apply-filter`) restores every pack source.
- **`file_protection.go`** — deletion-safety and edited-file tracking now work per pack directory instead of per BP/RP pair.
- **`watcher.go`** — watches every pack source and dispatches the correct `bp`/`rp`/`data` interruption.
- Symlink export is automatically disabled for multi-pack projects (it can only express a single BP/RP pair); it's unchanged for single-pack projects.
- Removed the now-unused `BehaviorFolder`/`ResourceFolder` accessors.

## Tests

New `test/multi_pack_test.go` (21 tests) plus a `test/testdata/multi_pack` project, covering config parsing/marshalling in both forms, version gating and validation errors, name/path resolution, tmp folder setup, watcher roots, in-place export, and end-to-end `local`, `exact`, `development` and `world` exports (including the missing-path failure case).

## Note for filter authors

Some filters will most likely need an update. Anything that assumes the working directory contains exactly `BP/` and `RP/` — hard-coded paths, globs over the two folders, or logic that writes to "the" behavior pack — will simply not see the extra packs in a multi-pack project. Single-pack projects are unaffected, so this is not an immediate break, but filters should be reviewed to iterate over the pack folders present in tmp rather than assuming the fixed pair.
